### PR TITLE
Basic maze rendering, maze styling, canvas control

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,15 @@
-from dash import Dash, html, dcc, callback, Output, Input
-import plotly.express as px
-import pandas as pd
+from dash import Dash, _dash_renderer
+import dash_mantine_components as dmc
 from app_layout import generate_layout
 
-import random
+_dash_renderer._set_react_version("18.2.0")
 
-app = Dash(__name__)
-app.layout = generate_layout()
+app = Dash(__name__,
+           external_stylesheets=dmc.styles.ALL
+           )
+app.layout = dmc.MantineProvider(
+    generate_layout()
+)
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/app.py
+++ b/app.py
@@ -4,12 +4,8 @@ from app_layout import generate_layout
 
 _dash_renderer._set_react_version("18.2.0")
 
-app = Dash(__name__,
-           external_stylesheets=dmc.styles.ALL
-           )
-app.layout = dmc.MantineProvider(
-    generate_layout()
-)
+app = Dash(__name__, external_stylesheets=dmc.styles.ALL)
+app.layout = dmc.MantineProvider(generate_layout())
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run_server(debug=True)

--- a/assets/js/00_canvas_listeners.js
+++ b/assets/js/00_canvas_listeners.js
@@ -100,7 +100,31 @@ const mazeStyleUpdateHandler = (State) => {
     State.mazeStyleUpdated = true;
 };
 
-function handleEventListeners(canvas, State, mode = 'attach') {
+const mazeResizer = (State, canvas, offscreenCanvas) => {
+    const prevCanvasWidth = canvas.width;
+    const prevCanvasHeight = canvas.height;
+
+    const rect = canvas.getBoundingClientRect();
+    console.log("Maze resize triggered", rect)
+    canvas.width = rect.width;
+    canvas.height = rect.height;
+    // let ctx = canvas.getContext("2d");
+    offscreenCanvas.width = canvas.width;
+    offscreenCanvas.height = canvas.height;
+
+    State.renderedImageCanvasOffsetCoords.x = State.renderedImageCanvasOffsetCoords.x + (canvas.width - prevCanvasWidth) / 2;
+    State.renderedImageCanvasOffsetCoords.y = State.renderedImageCanvasOffsetCoords.y + (canvas.height - prevCanvasHeight) / 2;
+    // State.cellSize = Math.min(
+    //     (canvas.width * State.zoomFactor) / State.mazeCellCounts.x,
+    //     (canvas.height * State.zoomFactor) / State.mazeCellCounts.y
+    // );
+
+
+
+    State.canvasResized = true;
+}
+
+function handleEventListeners(canvas, offscreenCanvas, State, mode = 'attach') {
 
     // Store handlers in the State object to ensure consistent references
     if (!State.handlers) {
@@ -111,6 +135,7 @@ function handleEventListeners(canvas, State, mode = 'attach') {
             panningStopperFn: () => panningStopper(State),
             minimapOnClickMoverFn: (event) => minimapOnClickMover(event, State, canvas),
             mazeStyleUpdateHandlerFn: () => mazeStyleUpdateHandler(State),
+            mazeResizerFn: () => mazeResizer(State, canvas, offscreenCanvas)
         };
     }
 
@@ -148,6 +173,11 @@ function handleEventListeners(canvas, State, mode = 'attach') {
             handler: State.handlers.mazeStyleUpdateHandlerFn,
             target: window, // Optional: Bind to a different target
         },
+        {
+            type: 'resize',
+            handler: State.handlers.mazeResizerFn,
+            target: window
+        }
     ];
 
     // Determine action based on the mode

--- a/assets/js/01_canvas_listeners.js
+++ b/assets/js/01_canvas_listeners.js
@@ -1,0 +1,163 @@
+console.log("Loading canvas listeners");
+const zoomHandler = (event, State) => {
+    State.isMinimapAnimating = false; // Cancel minimap animation
+    event.preventDefault();
+    if (!State.isZooming) State.isZooming = true;
+    const mousePosition = { // cursor position on canvas when event was triggered
+        x: event.offsetX,
+        y: event.offsetY
+    };
+
+    // where the cursor would have pointed in the image
+    // if no previous zooming or panning happened
+    // translation of cursor coordinates from Image to Canvas space;
+    // these operation cancel previous panning and zoom - coordinates without previous offset and zoom
+    // note: zoomFactor here is the original zoom or previous applied zoom
+    const worldPosition = keywiseOperation(mousePosition, State.renderedImageCanvasOffsetCoords, (mouse, offset) => (mouse - offset) / State.zoomFactor);
+
+    zoomIncrement = getZoomIncrement(State.zoomFactor, State.maxZoomFactor);
+
+    if (event.deltaY < 0) {
+        State.zoomFactor +=zoomIncrement;
+    } else {
+        State.zoomFactor -=zoomIncrement;
+    }
+    State.zoomFactor = Math.max(State.minZoomFactor, Math.min(State.zoomFactor, State.maxZoomFactor));
+
+    // how much to offset the image so that the cursor is still pointing at the same thing after zoom is applied
+    // world coordinates * zoomFactor = world coordinats with new zoom
+    // note: zoomFactor here is new zoom
+    State.renderedImageCanvasOffsetCoords = keywiseOperation(mousePosition, worldPosition, (m, w) => m - w * State.zoomFactor);
+
+    clearTimeout(State.zoomTimeout); // Clear any existing timeout
+    State.zoomTimeout = setTimeout(() => {
+        State.isZooming = false; // Mark zoom as complete after delay
+    }, State.zoomDelay); // Delay in milliseconds
+};
+
+const panningStarter = (event, State) => {
+    State.isMinimapAnimating = false; // Cancel minimap animation
+    State.isPanning = true; // Start panning
+    State.startingPanningCoords.x = event.clientX; // Track starting mouse position
+    State.startingPanningCoords.y = event.clientY;
+};
+
+const panningHandler = (event, State) => {
+    if (!State.isPanning) return; // Only pan if mouse is pressed
+
+    // Calculate the mouse movement (delta)
+    const deltaCoords = {
+        x: event.clientX - State.startingPanningCoords.x,
+        y: event.clientY - State.startingPanningCoords.y
+    };
+
+    // Update start position for next frame
+    State.startingPanningCoords.x = event.clientX;
+    State.startingPanningCoords.y = event.clientY;
+
+    // Update offsets based on mouse movement
+    State.renderedImageCanvasOffsetCoords = keywiseOperation(State.renderedImageCanvasOffsetCoords, deltaCoords, (coords, delta) => coords + delta);
+    
+};
+
+const panningStopper = (State) => {
+    State.isPanning = false;
+};
+
+const minimapOnClickMover = (event, State, canvas) => {
+    const mouseX = event.offsetX;
+    const mouseY = event.offsetY;
+
+    // Check if the click is inside the mini-map bounds
+    if (
+        mouseX >= State.miniMapOrigin.x &&
+        mouseX <= State.miniMapOrigin.x + State.miniMapDimensions.x &&
+        mouseY >= State.miniMapOrigin.y &&
+        mouseY <= State.miniMapOrigin.y + State.miniMapDimensions.y
+    ) {
+        // Calculate the relative position inside the mini-map
+        const scale = keywiseOperation(State.miniMapDimensions, State.mazeCellCounts, (mapDim, cell_count) => mapDim / cell_count);
+
+        // Calculate the corresponding coordinates in the main canvas
+        const targetX = (mouseX - State.miniMapOrigin.x) / scale.x; // Corresponding X in the main maze
+        const targetY = (mouseY - State.miniMapOrigin.y) / scale.y; // Corresponding Y in the main maze
+
+        // Update the offsets to center the viewport on the clicked position
+        // Ensure the center of the clicked position on the mini-map corresponds to the center on the full canvas
+        State.minimapTargetOffsetCoords.x = -(targetX * State.cellSize) + canvas.width / 2;
+        State.minimapTargetOffsetCoords.y = -(targetY * State.cellSize) + canvas.height / 2;
+
+        // Clamp the offsets to avoid scrolling out of bounds
+        State.minimapTargetOffsetCoords.x = Math.min(0, Math.max(State.minimapTargetOffsetCoords.x, -State.mazeCellCounts.x * State.cellSize + canvas.width));
+        State.minimapTargetOffsetCoords.y = Math.min(0, Math.max(State.minimapTargetOffsetCoords.y, -State.mazeCellCounts.y * State.cellSize + canvas.height));
+
+        State.isMinimapAnimating = true; // Start minimap animation
+    }
+};
+
+const mazeStyleUpdateHandler = (State) => {
+    State.mazeStyle = JSON.parse(window.localStorage.getItem('maze-style-store'));
+    State.mazeStyleUpdated = true;
+};
+
+function handleEventListeners(canvas, State, mode = 'attach') {
+
+    // Store handlers in the State object to ensure consistent references
+    if (!State.handlers) {
+        State.handlers = {
+            zoomHandlerFn: (event) => zoomHandler(event, State),
+            panningStarterFn: (event) => panningStarter(event, State),
+            panningHandlerFn: (event) => panningHandler(event, State),
+            panningStopperFn: () => panningStopper(State),
+            minimapOnClickMoverFn: (event) => minimapOnClickMover(event, State, canvas),
+            mazeStyleUpdateHandlerFn: () => mazeStyleUpdateHandler(State),
+        };
+    }
+
+    const listeners = [
+        // Zoom feature
+        {
+            type: 'wheel',
+            handler: State.handlers.zoomHandlerFn,
+        },
+        // Panning feature
+        {
+            type: 'mousedown',
+            handler: State.handlers.panningStarterFn
+        },
+        {
+            type: 'mousemove',
+            handler: State.handlers.panningHandlerFn
+        },
+        {
+            type: 'mouseup',
+            handler: State.handlers.panningStopperFn
+        },
+        {
+            type: 'mouseleave',
+            handler: State.handlers.panningStopperFn
+        },
+        // Mini-map click-to-move
+        {
+            type: 'click',
+            handler: State.handlers.minimapOnClickMoverFn
+        },
+        // Dynamic recoloring support
+        {
+            type: 'mazeStyleUpdated',
+            handler: State.handlers.mazeStyleUpdateHandlerFn,
+            target: window, // Optional: Bind to a different target
+        },
+    ];
+
+    // Determine action based on the mode
+    listeners.forEach(({ type, handler, target = canvas }) => {
+        if (mode === 'attach') {
+            target.addEventListener(type, handler);
+        } else if (mode === 'remove') {
+            target.removeEventListener(type, handler);
+        } else {
+            console.error(`Unknown mode: ${mode}`);
+        }
+    });
+}

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -69,17 +69,21 @@ function drawLabyrinthAsCells(canvasId, labyrinthData) {
     console.timeEnd('drawLabyrinthExecutionTime'); // End the timer
 }
 
-function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData) {
+function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1) {
     console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
     console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
     // Disable anti-aliasing (optional)
     offscreenCtx.imageSmoothingEnabled = false;
+    const canvasWidth = offscreenCtx.canvas.width;
+
+    // Dynamic checkered mode for small scales
+    const useCheckeredMode = cellSize <= 0.004 * canvasWidth;
 
     // Configuration constants
     const batchSize = 10000;
     const rectStyle = { fill: "#F6F6F8", stroke: "#F6F6F8", lineWidth: 1 };
     const lineStyle = { stroke: "#FFD700",
-                        lineWidth: Math.max(Math.round((cellSize * 0.1) / 2) * 2 + 1, 1), 
+                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 1), 
                         lineCap: "square", 
                         lineJoin: "square",
                         // shadow: "rgba(0, 0, 0, 0.5)",
@@ -118,50 +122,72 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
 
     // Loop over only path cells (even rows and columns)
     // Loop over all cells
-    for (let y = 0; y < rows; y++) {
-        const isEvenRow = y % 2 === 0;
-        for (let x = 0; x < cols; x++) {
-            const isEvenCol = x % 2 === 0;
+    
+    if (useCheckeredMode) {
+        const checkeredSize = Math.max(2, Math.floor(cellSize * zoomLevel)); // Scale dynamically with zoom
+        const patternCanvas = document.createElement('canvas');
+        const patternCtx = patternCanvas.getContext('2d');
+        patternCanvas.width = checkeredSize * 2;
+        patternCanvas.height = checkeredSize * 2;
 
-            if (labyrinthData[y][x] === 0 && isEvenRow && isEvenCol) {
-                // Path cell
-                const rect_x = (x - 1) / 2;
-                const rect_y = (y - 1) / 2;
-                rectPath.rect(snap(rect_x * cellSize), snap(rect_y * cellSize), cellSize, cellSize);
+        // Draw checkered pattern
+        patternCtx.fillStyle = rectStyle.fill; // Light color
+        patternCtx.fillRect(0, 0, checkeredSize, checkeredSize);
+        patternCtx.fillRect(checkeredSize, checkeredSize, checkeredSize, checkeredSize);
 
-            } else if (labyrinthData[y][x] === 1) {
-                // Wall cells
-                if (isEvenRow && !isEvenCol) {
-                    // Horizontal walls in even rows
+        patternCtx.fillStyle = lineStyle.stroke; // Darker color
+        patternCtx.fillRect(0, checkeredSize, checkeredSize, checkeredSize);
+        patternCtx.fillRect(checkeredSize, 0, checkeredSize, checkeredSize);
+
+        // Use pattern as fill style
+        const pattern = offscreenCtx.createPattern(patternCanvas, 'repeat');
+        offscreenCtx.fillStyle = pattern;
+        offscreenCtx.fillRect(0, 0, cellSize * (cols - 1) / 2, cellSize * (rows - 1) / 2);
+    } else {
+        for (let y = 0; y < rows; y++) {
+            const isEvenRow = y % 2 === 0;
+            for (let x = 0; x < cols; x++) {
+                const isEvenCol = x % 2 === 0;
+
+                if (labyrinthData[y][x] === 0 && isEvenRow && isEvenCol) {
+                    // Path cell
                     const rect_x = (x - 1) / 2;
-                    const rect_y = y / 2;
-                    linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
-                    linePath.lineTo(snap((rect_x + 1) * cellSize), snap(rect_y * cellSize));
-                } else if (!isEvenRow && isEvenCol) {
-                    // Vertical walls in odd rows
-                    const rect_x = x / 2;
                     const rect_y = (y - 1) / 2;
-                    linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
-                    linePath.lineTo(snap(rect_x * cellSize), snap((rect_y + 1) * cellSize));
+                    rectPath.rect(snap(rect_x * cellSize), snap(rect_y * cellSize), cellSize, cellSize);
+
+                } else if (labyrinthData[y][x] === 1) {
+                    // Wall cells
+                    if (isEvenRow && !isEvenCol) {
+                        // Horizontal walls in even rows
+                        const rect_x = (x - 1) / 2;
+                        const rect_y = y / 2;
+                        linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
+                        linePath.lineTo(snap((rect_x + 1) * cellSize), snap(rect_y * cellSize));
+                    } else if (!isEvenRow && isEvenCol) {
+                        // Vertical walls in odd rows
+                        const rect_x = x / 2;
+                        const rect_y = (y - 1) / 2;
+                        linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
+                        linePath.lineTo(snap(rect_x * cellSize), snap((rect_y + 1) * cellSize));
+                    }
+                }
+
+                // Handle batching
+                if (++count >= batchSize) {
+                    applyRectStyles();
+                    offscreenCtx.fill(rectPath);
+                    offscreenCtx.stroke(rectPath);
+
+                    applyLineStyles();
+                    offscreenCtx.stroke(linePath);
+
+                    rectPath = new Path2D();
+                    linePath = new Path2D();
+                    count = 0;
                 }
             }
-
-            // Handle batching
-            if (++count >= batchSize) {
-                applyRectStyles();
-                offscreenCtx.fill(rectPath);
-                offscreenCtx.stroke(rectPath);
-
-                applyLineStyles();
-                offscreenCtx.stroke(linePath);
-
-                rectPath = new Path2D();
-                linePath = new Path2D();
-                count = 0;
-            }
         }
-    }
-
+    }    
 
     // Render remaining batch
     applyRectStyles();

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -7,12 +7,12 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const canvasWidth = offscreenCtx.canvas.width;
 
     // Dynamic checkered mode for small scales
-    const useCheckeredMode = cellSize <= 0.004 * canvasWidth;
+    const useCheckeredMode = cellSize <= 0.005 * canvasWidth;
 
     // Configuration constants
     const batchSize = 10000;
     const rectStyle = { fill: "#F6F6F8", stroke: "#F6F6F8", lineWidth: 1 };
-    const lineStyle = { stroke: "#FFD700",
+    const lineStyle = { stroke: "#63C5DA",
                         lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
                         lineCap: "square", 
                         lineJoin: "square",

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -71,7 +71,7 @@ function drawLabyrinthAsCells(canvasId, labyrinthData) {
 
 function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData) {
     console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
-
+    console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
     // Disable anti-aliasing (optional)
     offscreenCtx.imageSmoothingEnabled = false;
 

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -1,5 +1,9 @@
 // Define the drawing logic globally
-function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
+function v1drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
+
+    // default code version
+
+
     // console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
     // console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
     // Disable anti-aliasing (optional)
@@ -102,6 +106,168 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
                 }
             }
         }
+        linePathArray.push(linePath);
+        
+        // Render remaining batch
+        applyRectStyles();
+        offscreenCtx.fillRect(0, 0,
+            (cols - 1) / 2 * cellSize, 
+            (rows - 1) / 2 * cellSize
+        );
+        applyLineStyles();
+        for (const path of linePathArray) {
+            offscreenCtx.stroke(path);
+        }
+        // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
+    }    
+}
+
+// Export the function to make it accessible
+// window.drawLabyrinthOffscreen = drawLabyrinthOffscreen;
+
+// Define the drawing logic globally
+function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
+
+    // Processes walls in 2 separate loops (horizontal and vertical) and extends lines where the wall is longer than one cell
+    // Wins original, 1.5 - 2x boost
+
+
+    // console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
+    // console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
+    // Disable anti-aliasing (optional)
+    offscreenCtx.imageSmoothingEnabled = false;
+    const canvasWidth = offscreenCtx.canvas.width;
+    const canvasHeight = offscreenCtx.canvas.height;
+
+    // Dynamic checkered mode for small scales
+    // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
+    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
+    // Configuration constants
+    // const batchSize = 500;
+    const rectStyle = { fill: mazeStyle.pathFill, stroke: mazeStyle.pathFill, lineWidth: 1 };
+    const lineStyle = { stroke: mazeStyle.wallStroke,
+                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 1), 
+                        lineCap: "square", 
+                        lineJoin: "square",
+                        // shadow: "rgba(0, 0, 0, 0.5)",
+                        // shadowBlur: 0,
+                        // shadowOffsetX: 0,
+                        // shadowOffsetY: 0,
+    };
+
+    let count = 0;
+
+    // Path caching setup
+    let linePathArray = []; 
+
+    // Predefine paths
+    let linePath = new Path2D();
+
+    // Function to apply rectangle styles
+    function applyRectStyles() {
+        offscreenCtx.fillStyle = rectStyle.fill;
+        offscreenCtx.strokeStyle = rectStyle.stroke;
+        offscreenCtx.lineWidth = rectStyle.lineWidth;
+    }
+
+    // Function to apply line styles
+    function applyLineStyles() {
+        offscreenCtx.strokeStyle = lineStyle.stroke;
+        offscreenCtx.lineWidth = lineStyle.lineWidth;
+        offscreenCtx.lineCap = lineStyle.lineCap;
+        offscreenCtx.lineJoin = lineStyle.lineJoin;
+        // offscreenCtx.shadowColor = lineStyle.shadow;
+        // offscreenCtx.shadowBlur = lineStyle.shadowBlur;
+        // offscreenCtx.shadowOffsetX = lineStyle.shadowOffsetX;
+        // offscreenCtx.shadowOffsetY = lineStyle.shadowOffsetY;
+    }
+
+    // Loop over all cells, render only walls
+    
+    if (useCheckeredMode) {
+        const checkeredSize = Math.max(2, Math.floor(cellSize * zoomLevel)); // Scale dynamically with zoom
+        const patternCanvas = document.createElement('canvas');
+        const patternCtx = patternCanvas.getContext('2d');
+        patternCanvas.width = checkeredSize * 2;
+        patternCanvas.height = checkeredSize * 2;
+
+        // Draw checkered pattern
+        patternCtx.fillStyle = rectStyle.fill; // Light color
+        patternCtx.fillRect(0, 0, checkeredSize, checkeredSize);
+        patternCtx.fillRect(checkeredSize, checkeredSize, checkeredSize, checkeredSize);
+
+        patternCtx.fillStyle = lineStyle.stroke; // Darker color
+        patternCtx.fillRect(0, checkeredSize, checkeredSize, checkeredSize);
+        patternCtx.fillRect(checkeredSize, 0, checkeredSize, checkeredSize);
+
+        // Use pattern as fill style
+        const pattern = offscreenCtx.createPattern(patternCanvas, 'repeat');
+        offscreenCtx.fillStyle = pattern;
+        offscreenCtx.fillRect(0, 0, cellSize * (cols - 1) / 2, cellSize * (rows - 1) / 2);
+    } else {
+        for (let y = 0; y < rows; y+=2) {
+            let x = 1;
+            while (x < cols) {
+                if (labyrinthData[y][x] === 0) {
+                    x+=2;
+                } else if (labyrinthData[y][x] === 1) {
+                    linePath.moveTo( cellSize * (x-1) / 2, cellSize * y / 2);
+                    let drawLine = false;                    
+                    while (x < cols && !drawLine) {
+                        if (labyrinthData[y][x] === 1) {
+                            if (x + 2 === cols) {
+                                linePath.lineTo(cellSize * ((x + 1) / 2), cellSize * y / 2);
+                                drawLine = true;
+                            }
+                            x+=2;
+                        } else if (labyrinthData[y][x] === 0) {
+                            linePath.lineTo(cellSize * ((x - 1) / 2), cellSize * y / 2)
+                            x+=2;
+                            drawLine = true;
+                        }
+                    }
+                }
+                // Handle batching
+                // if (++count >= batchSize) {
+                //     console.log("BATCH")
+                //     linePathArray.push(linePath);
+                //     linePath = new Path2D();
+                //     count = 0;
+                // }
+            }
+        }
+
+        for (let x = 0; x < cols; x+=2) {
+            let y = 1;
+            while (y < rows) {
+                if (labyrinthData[y][x] === 0) {
+                    y+=2;
+                } else if (labyrinthData[y][x] === 1) {
+                    linePath.moveTo( cellSize * x / 2, cellSize * (y - 1) / 2);
+                    let drawLine = false;
+                    while (y < rows && !drawLine) {
+                        if (labyrinthData[y][x] === 1) {
+                            if (y + 2 === rows) {
+                                linePath.lineTo(cellSize * (x / 2), cellSize * ((y + 1) / 2));
+                                drawLine = true;
+                            }
+                            y+=2;
+                        } else if (labyrinthData[y][x] === 0) {
+                            linePath.lineTo(cellSize * (x / 2), cellSize * ((y - 1) / 2));
+                            y+=2;
+                            drawLine = true;
+                        }
+                    }
+                }
+                // Handle batching
+                // if (++count >= batchSize) {
+                //     linePathArray.push(linePath);
+                //     linePath = new Path2D();
+                //     count = 0;
+                // }   
+            }
+        }
+     
         linePathArray.push(linePath);
         
         // Render remaining batch

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -1,74 +1,4 @@
 // Define the drawing logic globally
-function drawLabyrinthAsCells(canvasId, labyrinthData) {
-    console.time('drawLabyrinthExecutionTime'); // Start the timer
-
-    const canvas = document.getElementById(canvasId);
-    if (!canvas) return;
-    
-    // // Dynamically set canvas dimensions
-    const rect = canvas.getBoundingClientRect();
-    canvas.width = rect.width;
-    canvas.height = rect.height;
-
-    const ctx = canvas.getContext("2d");
-
-    const rows = labyrinthData.length;
-    const cols = labyrinthData[0].length;
-
-    // Calculate integer cell size and adjust canvas dimensions
-    const cellSize = Math.ceil(canvas.width / cols);
-    canvas.width = cellSize * cols;
-    canvas.height = cellSize * rows;
-
-    // Disable anti-aliasing (optional)
-    ctx.imageSmoothingEnabled = false;
-
-    ctx.beginPath();
-    let batchSize = 10000; // Draw in chunks of 10,000 cells
-    let count = 0;
-    
-    for (let y = 0; y < rows; y++) {
-        for (let x = 0; x < cols; x++) {
-            if (labyrinthData[y][x] === 1) {
-                ctx.rect(x * cellSize, y * cellSize, cellSize, cellSize);
-                count++;
-                if (count >= batchSize) {
-                    ctx.fillStyle = "#daa520";
-                    ctx.fill();
-                    ctx.beginPath(); // Start a new batch
-                    count = 0;
-                }
-            }
-        }
-    }
-    // Final fill for remaining cells
-    ctx.fillStyle = "#daa520";
-    ctx.fill();
-
-
-    count = 0;
-    ctx.beginPath();
-   
-    for (let y = 0; y < rows; y++) {
-        for (let x = 0; x < cols; x++) {
-            if (labyrinthData[y][x] === 0) {
-                ctx.rect(x * cellSize, y * cellSize, cellSize, cellSize);
-                count++;
-                if (count >= batchSize) {
-                    ctx.fillStyle = "#FFFFFF";
-                    ctx.fill();
-                    ctx.beginPath(); // Start a new batch
-                    count = 0;
-                }
-            }
-        }
-    }
-    // Final fill for remaining cells
-    ctx.fillStyle = "#FFFFFF";
-    ctx.fill();
-    console.timeEnd('drawLabyrinthExecutionTime'); // End the timer
-}
-
 function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1) {
     console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
     console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
@@ -83,7 +13,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const batchSize = 10000;
     const rectStyle = { fill: "#F6F6F8", stroke: "#F6F6F8", lineWidth: 1 };
     const lineStyle = { stroke: "#FFD700",
-                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 1), 
+                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
                         lineCap: "square", 
                         lineJoin: "square",
                         // shadow: "rgba(0, 0, 0, 0.5)",

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -9,7 +9,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     // Dynamic checkered mode for small scales
     const useCheckeredMode = cellSize <= 0.005 * canvasWidth;
     // Configuration constants
-    const batchSize = 10000;
+    const batchSize = 500;
     const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };
     const lineStyle = { stroke: mazeStyle.wallStroke,
                         lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
@@ -22,6 +22,10 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     };
 
     let count = 0;
+
+    // Path caching setup
+    let rectPathArray = [];
+    let linePathArray = []; 
 
     // Predefine paths
     let rectPath = new Path2D();
@@ -103,12 +107,14 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
 
                 // Handle batching
                 if (++count >= batchSize) {
-                    applyRectStyles();
-                    offscreenCtx.fill(rectPath);
-                    offscreenCtx.stroke(rectPath);
+                    // applyRectStyles();
+                    // offscreenCtx.fill(rectPath);
+                    // offscreenCtx.stroke(rectPath);
 
-                    applyLineStyles();
-                    offscreenCtx.stroke(linePath);
+                    // applyLineStyles();
+                    // offscreenCtx.stroke(linePath);
+                    rectPathArray.push(rectPath);
+                    linePathArray.push(linePath);
 
                     rectPath = new Path2D();
                     linePath = new Path2D();
@@ -117,16 +123,21 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
             }
         }
     }    
+    rectPathArray.push(rectPath);
+    linePathArray.push(linePath);
 
     // Render remaining batch
     applyRectStyles();
-    offscreenCtx.fill(rectPath);
-    offscreenCtx.stroke(rectPath);
+    for (const path of rectPathArray) {
+        offscreenCtx.fill(path);
+        offscreenCtx.stroke(path);
+    }
 
     applyLineStyles();
-    offscreenCtx.stroke(linePath);
-
-    // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
+    for (const path of linePathArray) {
+        offscreenCtx.stroke(path);
+    }
+    console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
 }
 
 // Export the function to make it accessible

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -9,7 +9,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
 
     // Dynamic checkered mode for small scales
     // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
-    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth);
+    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
     // Configuration constants
     const batchSize = 500;
     const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -1,18 +1,17 @@
 // Define the drawing logic globally
-function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1) {
-    console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
-    console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
+function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
+    // console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
+    // console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
     // Disable anti-aliasing (optional)
     offscreenCtx.imageSmoothingEnabled = false;
     const canvasWidth = offscreenCtx.canvas.width;
 
     // Dynamic checkered mode for small scales
     const useCheckeredMode = cellSize <= 0.005 * canvasWidth;
-
     // Configuration constants
     const batchSize = 10000;
-    const rectStyle = { fill: "#F6F6F8", stroke: "#F6F6F8", lineWidth: 1 };
-    const lineStyle = { stroke: "#63C5DA",
+    const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };
+    const lineStyle = { stroke: mazeStyle.wallStroke,
                         lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
                         lineCap: "square", 
                         lineJoin: "square",
@@ -79,7 +78,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
             for (let x = 0; x < cols; x++) {
                 const isEvenCol = x % 2 === 0;
 
-                if (labyrinthData[y][x] === 0 && isEvenRow && isEvenCol) {
+                if (labyrinthData[y][x] === 0 && !isEvenRow && !isEvenCol) {
                     // Path cell
                     const rect_x = (x - 1) / 2;
                     const rect_y = (y - 1) / 2;
@@ -127,7 +126,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     applyLineStyles();
     offscreenCtx.stroke(linePath);
 
-    console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
+    // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
 }
 
 // Export the function to make it accessible

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -10,7 +10,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const useCheckeredMode = cellSize <= 0.005 * canvasWidth;
     // Configuration constants
     const batchSize = 500;
-    const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };
+    const rectStyle = { fill: mazeStyle.pathFill, stroke: mazeStyle.pathFill, lineWidth: 1 };
     const lineStyle = { stroke: mazeStyle.wallStroke,
                         lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
                         lineCap: "square", 

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -1,138 +1,11 @@
 // Define the drawing logic globally
-function v1drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
-
-    // default code version
-
-
-    // console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
-    // console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
-    // Disable anti-aliasing (optional)
-    offscreenCtx.imageSmoothingEnabled = false;
-    const canvasWidth = offscreenCtx.canvas.width;
-    const canvasHeight = offscreenCtx.canvas.height;
-
-    // Dynamic checkered mode for small scales
-    // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
-    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
-    // Configuration constants
-    const batchSize = 500;
-    const rectStyle = { fill: mazeStyle.pathFill, stroke: mazeStyle.pathFill, lineWidth: 1 };
-    const lineStyle = { stroke: mazeStyle.wallStroke,
-                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 1), 
-                        lineCap: "square", 
-                        lineJoin: "square",
-                        // shadow: "rgba(0, 0, 0, 0.5)",
-                        // shadowBlur: 0,
-                        // shadowOffsetX: 0,
-                        // shadowOffsetY: 0,
-    };
-
-    let count = 0;
-
-    // Path caching setup
-    let linePathArray = []; 
-
-    // Predefine paths
-    let linePath = new Path2D();
-
-    // Function to apply rectangle styles
-    function applyRectStyles() {
-        offscreenCtx.fillStyle = rectStyle.fill;
-        offscreenCtx.strokeStyle = rectStyle.stroke;
-        offscreenCtx.lineWidth = rectStyle.lineWidth;
-    }
-
-    // Function to apply line styles
-    function applyLineStyles() {
-        offscreenCtx.strokeStyle = lineStyle.stroke;
-        offscreenCtx.lineWidth = lineStyle.lineWidth;
-        offscreenCtx.lineCap = lineStyle.lineCap;
-        offscreenCtx.lineJoin = lineStyle.lineJoin;
-        // offscreenCtx.shadowColor = lineStyle.shadow;
-        // offscreenCtx.shadowBlur = lineStyle.shadowBlur;
-        // offscreenCtx.shadowOffsetX = lineStyle.shadowOffsetX;
-        // offscreenCtx.shadowOffsetY = lineStyle.shadowOffsetY;
-    }
-
-    // Loop over all cells, render only walls
-    
-    if (useCheckeredMode) {
-        const checkeredSize = Math.max(2, Math.floor(cellSize * zoomLevel)); // Scale dynamically with zoom
-        const patternCanvas = document.createElement('canvas');
-        const patternCtx = patternCanvas.getContext('2d');
-        patternCanvas.width = checkeredSize * 2;
-        patternCanvas.height = checkeredSize * 2;
-
-        // Draw checkered pattern
-        patternCtx.fillStyle = rectStyle.fill; // Light color
-        patternCtx.fillRect(0, 0, checkeredSize, checkeredSize);
-        patternCtx.fillRect(checkeredSize, checkeredSize, checkeredSize, checkeredSize);
-
-        patternCtx.fillStyle = lineStyle.stroke; // Darker color
-        patternCtx.fillRect(0, checkeredSize, checkeredSize, checkeredSize);
-        patternCtx.fillRect(checkeredSize, 0, checkeredSize, checkeredSize);
-
-        // Use pattern as fill style
-        const pattern = offscreenCtx.createPattern(patternCanvas, 'repeat');
-        offscreenCtx.fillStyle = pattern;
-        offscreenCtx.fillRect(0, 0, cellSize * (cols - 1) / 2, cellSize * (rows - 1) / 2);
-    } else {
-        for (let y = 0; y < rows; y++) {
-            const isEvenRow = y % 2 === 0;
-            for (let x = 0; x < cols; x++) {
-                const isEvenCol = x % 2 === 0;
-                if (labyrinthData[y][x] === 1) {
-                    // Wall cells
-                    if (isEvenRow && !isEvenCol) {
-                        // Horizontal walls in even rows
-                        const rect_x = (x - 1) / 2;
-                        const rect_y = y / 2;
-                        linePath.moveTo(rect_x * cellSize, rect_y * cellSize);
-                        linePath.lineTo((rect_x + 1) * cellSize, rect_y * cellSize);
-                    } else if (!isEvenRow && isEvenCol) {
-                        // Vertical walls in odd rows
-                        const rect_x = x / 2;
-                        const rect_y = (y - 1) / 2;
-                        linePath.moveTo(rect_x * cellSize, rect_y * cellSize);
-                        linePath.lineTo(rect_x * cellSize, (rect_y + 1) * cellSize);
-                    }
-                }
-
-                // Handle batching
-                if (++count >= batchSize) {
-                    linePathArray.push(linePath);
-                    linePath = new Path2D();
-                    count = 0;
-                }
-            }
-        }
-        linePathArray.push(linePath);
-        
-        // Render remaining batch
-        applyRectStyles();
-        offscreenCtx.fillRect(0, 0,
-            (cols - 1) / 2 * cellSize, 
-            (rows - 1) / 2 * cellSize
-        );
-        applyLineStyles();
-        for (const path of linePathArray) {
-            offscreenCtx.stroke(path);
-        }
-        // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
-    }    
-}
-
-// Export the function to make it accessible
-// window.drawLabyrinthOffscreen = drawLabyrinthOffscreen;
-
-// Define the drawing logic globally
 function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomLevel=1, mazeStyle) {
 
     // Processes walls in 2 separate loops (horizontal and vertical) and extends lines where the wall is longer than one cell
     // Wins original, 1.5 - 2x boost
 
 
-    // console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
+    console.time('drawLabyrinthOffscreenExecutionTime'); // Start the timer
     // console.log('Rendering maze: ', rows, 'x', cols, ' with cellSize = ', cellSize);
     // Disable anti-aliasing (optional)
     offscreenCtx.imageSmoothingEnabled = false;
@@ -141,7 +14,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
 
     // Dynamic checkered mode for small scales
     // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
-    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
+    const useCheckeredMode = false; //cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
     // Configuration constants
     // const batchSize = 500;
     const rectStyle = { fill: mazeStyle.pathFill, stroke: mazeStyle.pathFill, lineWidth: 1 };
@@ -155,8 +28,6 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
                         // shadowOffsetY: 0,
     };
 
-    let count = 0;
-
     // Path caching setup
     let linePathArray = []; 
 
@@ -205,6 +76,8 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
         offscreenCtx.fillStyle = pattern;
         offscreenCtx.fillRect(0, 0, cellSize * (cols - 1) / 2, cellSize * (rows - 1) / 2);
     } else {
+        console.time("Processing horizontal walls")
+        // Draw horizontal walls
         for (let y = 0; y < rows; y+=2) {
             let x = 1;
             while (x < cols) {
@@ -227,16 +100,11 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
                         }
                     }
                 }
-                // Handle batching
-                // if (++count >= batchSize) {
-                //     console.log("BATCH")
-                //     linePathArray.push(linePath);
-                //     linePath = new Path2D();
-                //     count = 0;
-                // }
             }
         }
-
+        console.timeEnd("Processing horizontal walls")
+        //Draw vertical walls
+        console.time("Processing vertical walls")
         for (let x = 0; x < cols; x+=2) {
             let y = 1;
             while (y < rows) {
@@ -258,29 +126,65 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
                             drawLine = true;
                         }
                     }
-                }
-                // Handle batching
-                // if (++count >= batchSize) {
-                //     linePathArray.push(linePath);
-                //     linePath = new Path2D();
-                //     count = 0;
-                // }   
+                }  
             }
         }
+        console.timeEnd("Processing vertical walls")
      
         linePathArray.push(linePath);
-        
-        // Render remaining batch
+
+        // Pre-calculate the width and height of the floor
+        const numCellsCols = (cols - 1) / 2;
+        const numCellsRows = (rows - 1) / 2;
+        const floorWidth = numCellsCols * cellSize;
+        const floorHeight = numCellsRows * cellSize;
+
+        // Cover floor with main color
         applyRectStyles();
-        offscreenCtx.fillRect(0, 0,
-            (cols - 1) / 2 * cellSize, 
-            (rows - 1) / 2 * cellSize
-        );
+        offscreenCtx.fillRect(0, 0, floorWidth, floorHeight);
+
+        // Prepare floor image as imageData
+        const secondaryColor = hexToRgba("#FFD2D2");
+        const floorImageDataArray = new Uint8ClampedArray(numCellsCols * numCellsRows * 4);
+
+        // Process secondary color tiles only (optimized with direct array access)
+        
+        for (let y = 1; y < rows; y += 2) {
+            for (let x = 1; x < cols; x += 2) {
+                if (labyrinthData[y][x] === 0) {
+                    const cellRow = (y - 1) / 2;
+                    const cellCol = (x - 1) / 2;
+                    const cellDataStart = (cellRow * numCellsCols + cellCol) * 4;
+                    // Directly assign to the array
+                    floorImageDataArray[cellDataStart] = secondaryColor[0]; // R
+                    floorImageDataArray[cellDataStart + 1] = secondaryColor[1]; // G
+                    floorImageDataArray[cellDataStart + 2] = secondaryColor[2]; // B
+                    floorImageDataArray[cellDataStart + 3] = secondaryColor[3]; // A
+                }
+            }
+        }
+        const floorImageData = new ImageData(floorImageDataArray, numCellsCols);
+        // Create buffer canvas to allow scaling on image data
+        const bgCanvas = document.createElement('canvas');
+        bgCanvas.width = numCellsCols;
+        bgCanvas.height = numCellsRows;
+        const bgCtx = bgCanvas.getContext('2d');
+        bgCtx.putImageData(floorImageData, 0, 0);
+
+        // Draw the scaled image to the offscreen canvas
+        offscreenCtx.save(); // Save state for transformations
+        offscreenCtx.scale(cellSize, cellSize);
+        offscreenCtx.drawImage(bgCanvas, 0, 0); // Draw the image once at the scaled size
+        offscreenCtx.restore();
+
+        //Draw walls
+        console.time("Drawing walls")
         applyLineStyles();
         for (const path of linePathArray) {
             offscreenCtx.stroke(path);
         }
-        // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
+        console.timeEnd("Drawing walls")
+        console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
     }    
 }
 

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -14,7 +14,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
 
     // Dynamic checkered mode for small scales
     // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
-    const useCheckeredMode = false; //cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth) || cellSize <= 4;
+    const useCheckeredMode = cellSize <= 4;
     // Configuration constants
     // const batchSize = 500;
     const rectStyle = { fill: mazeStyle.pathFill, stroke: mazeStyle.pathFill, lineWidth: 1 };
@@ -143,39 +143,41 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
         applyRectStyles();
         offscreenCtx.fillRect(0, 0, floorWidth, floorHeight);
 
-        // Prepare floor image as imageData
-        const secondaryColor = hexToRgba("#FFD2D2");
-        const floorImageDataArray = new Uint8ClampedArray(numCellsCols * numCellsRows * 4);
+        // Prepare floor image as imageData - perform only if secondary color is in the data
+        if (false) { // temporary way to prevent below from from execution
+            const secondaryColor = hexToRgba("#FFD2D2");
+            const floorImageDataArray = new Uint8ClampedArray(numCellsCols * numCellsRows * 4);
 
-        // Process secondary color tiles only (optimized with direct array access)
-        
-        for (let y = 1; y < rows; y += 2) {
-            for (let x = 1; x < cols; x += 2) {
-                if (labyrinthData[y][x] === 0) {
-                    const cellRow = (y - 1) / 2;
-                    const cellCol = (x - 1) / 2;
-                    const cellDataStart = (cellRow * numCellsCols + cellCol) * 4;
-                    // Directly assign to the array
-                    floorImageDataArray[cellDataStart] = secondaryColor[0]; // R
-                    floorImageDataArray[cellDataStart + 1] = secondaryColor[1]; // G
-                    floorImageDataArray[cellDataStart + 2] = secondaryColor[2]; // B
-                    floorImageDataArray[cellDataStart + 3] = secondaryColor[3]; // A
+            // Process secondary color tiles only (optimized with direct array access)
+            
+            for (let y = 1; y < rows; y += 2) {
+                for (let x = 1; x < cols; x += 2) {
+                    if (labyrinthData[y][x] === 0) {
+                        const cellRow = (y - 1) / 2;
+                        const cellCol = (x - 1) / 2;
+                        const cellDataStart = (cellRow * numCellsCols + cellCol) * 4;
+                        // Directly assign to the array
+                        floorImageDataArray[cellDataStart] = secondaryColor[0]; // R
+                        floorImageDataArray[cellDataStart + 1] = secondaryColor[1]; // G
+                        floorImageDataArray[cellDataStart + 2] = secondaryColor[2]; // B
+                        floorImageDataArray[cellDataStart + 3] = secondaryColor[3]; // A
+                    }
                 }
             }
-        }
-        const floorImageData = new ImageData(floorImageDataArray, numCellsCols);
-        // Create buffer canvas to allow scaling on image data
-        const bgCanvas = document.createElement('canvas');
-        bgCanvas.width = numCellsCols;
-        bgCanvas.height = numCellsRows;
-        const bgCtx = bgCanvas.getContext('2d');
-        bgCtx.putImageData(floorImageData, 0, 0);
+            const floorImageData = new ImageData(floorImageDataArray, numCellsCols);
+            // Create buffer canvas to allow scaling on image data
+            const bgCanvas = document.createElement('canvas');
+            bgCanvas.width = numCellsCols;
+            bgCanvas.height = numCellsRows;
+            const bgCtx = bgCanvas.getContext('2d');
+            bgCtx.putImageData(floorImageData, 0, 0);
 
-        // Draw the scaled image to the offscreen canvas
-        offscreenCtx.save(); // Save state for transformations
-        offscreenCtx.scale(cellSize, cellSize);
-        offscreenCtx.drawImage(bgCanvas, 0, 0); // Draw the image once at the scaled size
-        offscreenCtx.restore();
+            // Draw the scaled image to the offscreen canvas
+            offscreenCtx.save(); // Save state for transformations
+            offscreenCtx.scale(cellSize, cellSize);
+            offscreenCtx.drawImage(bgCanvas, 0, 0); // Draw the image once at the scaled size
+            offscreenCtx.restore();
+        }
 
         //Draw walls
         console.time("Drawing walls")
@@ -184,8 +186,8 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
             offscreenCtx.stroke(path);
         }
         console.timeEnd("Drawing walls")
-        console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
     }    
+    console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
 }
 
 // Export the function to make it accessible

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -117,48 +117,51 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const snap = (val) => Math.round(val);
 
     // Loop over only path cells (even rows and columns)
-    for (let y = 1; y < rows; y += 2) {
-        for (let x = 1; x < cols; x += 2) {
-            if (labyrinthData[y][x] === 0) { // Path cell
+    // Loop over all cells
+    for (let y = 0; y < rows; y++) {
+        const isEvenRow = y % 2 === 0;
+        for (let x = 0; x < cols; x++) {
+            const isEvenCol = x % 2 === 0;
+
+            if (labyrinthData[y][x] === 0 && isEvenRow && isEvenCol) {
+                // Path cell
                 const rect_x = (x - 1) / 2;
                 const rect_y = (y - 1) / 2;
-
                 rectPath.rect(snap(rect_x * cellSize), snap(rect_y * cellSize), cellSize, cellSize);
 
-                // Check neighbors to add strokes (walls)
-                if (y > 0 && labyrinthData[y - 1][x] === 1) { // Wall above
+            } else if (labyrinthData[y][x] === 1) {
+                // Wall cells
+                if (isEvenRow && !isEvenCol) {
+                    // Horizontal walls in even rows
+                    const rect_x = (x - 1) / 2;
+                    const rect_y = y / 2;
                     linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
                     linePath.lineTo(snap((rect_x + 1) * cellSize), snap(rect_y * cellSize));
-                }
-                if (y < rows - 1 && labyrinthData[y + 1][x] === 1) { // Wall below
-                    linePath.moveTo(snap(rect_x * cellSize), snap((rect_y + 1) * cellSize));
-                    linePath.lineTo(snap((rect_x + 1) * cellSize), snap((rect_y + 1) * cellSize));
-                }
-                if (x > 0 && labyrinthData[y][x - 1] === 1) { // Wall to the left
+                } else if (!isEvenRow && isEvenCol) {
+                    // Vertical walls in odd rows
+                    const rect_x = x / 2;
+                    const rect_y = (y - 1) / 2;
                     linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
                     linePath.lineTo(snap(rect_x * cellSize), snap((rect_y + 1) * cellSize));
                 }
-                if (x < cols - 1 && labyrinthData[y][x + 1] === 1) { // Wall to the right
-                    linePath.moveTo(snap((rect_x + 1) * cellSize), snap(rect_y * cellSize));
-                    linePath.lineTo(snap((rect_x + 1) * cellSize), snap((rect_y + 1) * cellSize));
-                }
+            }
 
-                // Render batch when size is reached
-                if (++count >= batchSize) {
-                    applyRectStyles();
-                    offscreenCtx.fill(rectPath);
-                    offscreenCtx.stroke(rectPath);
+            // Handle batching
+            if (++count >= batchSize) {
+                applyRectStyles();
+                offscreenCtx.fill(rectPath);
+                offscreenCtx.stroke(rectPath);
 
-                    applyLineStyles();
-                    offscreenCtx.stroke(linePath);
+                applyLineStyles();
+                offscreenCtx.stroke(linePath);
 
-                    rectPath = new Path2D();
-                    linePath = new Path2D();
-                    count = 0;
-                }
+                rectPath = new Path2D();
+                linePath = new Path2D();
+                count = 0;
             }
         }
     }
+
 
     // Render remaining batch
     applyRectStyles();

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -79,13 +79,13 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const batchSize = 10000;
     const rectStyle = { fill: "#F6F6F8", stroke: "#F6F6F8", lineWidth: 1 };
     const lineStyle = { stroke: "#FFD700",
-                        lineWidth: Math.max(Math.round((cellSize * 0.05) / 2) * 2 + 1, 1), 
-                        shadow: "rgba(0, 0, 0, 0.5)",
-                        shadowBlur: 0,
-                        shadowOffsetX: 0,
-                        shadowOffsetY: 0,
-                        lineCap: "round", 
-                        lineJoin: "round" 
+                        lineWidth: Math.max(Math.round((cellSize * 0.1) / 2) * 2 + 1, 1), 
+                        lineCap: "square", 
+                        lineJoin: "square",
+                        // shadow: "rgba(0, 0, 0, 0.5)",
+                        // shadowBlur: 0,
+                        // shadowOffsetX: 0,
+                        // shadowOffsetY: 0,
     };
 
     let count = 0;
@@ -107,10 +107,10 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
         offscreenCtx.lineWidth = lineStyle.lineWidth;
         offscreenCtx.lineCap = lineStyle.lineCap;
         offscreenCtx.lineJoin = lineStyle.lineJoin;
-        offscreenCtx.shadowColor = lineStyle.shadow;
-        offscreenCtx.shadowBlur = lineStyle.shadowBlur;
-        offscreenCtx.shadowOffsetX = lineStyle.shadowOffsetX;
-        offscreenCtx.shadowOffsetY = lineStyle.shadowOffsetY;
+        // offscreenCtx.shadowColor = lineStyle.shadow;
+        // offscreenCtx.shadowBlur = lineStyle.shadowBlur;
+        // offscreenCtx.shadowOffsetX = lineStyle.shadowOffsetX;
+        // offscreenCtx.shadowOffsetY = lineStyle.shadowOffsetY;
     }
 
     // Snap to integer pixel values

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -14,7 +14,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     const batchSize = 500;
     const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };
     const lineStyle = { stroke: mazeStyle.wallStroke,
-                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 2), 
+                        lineWidth: Math.max(Math.round((cellSize * 0.1)), 1), 
                         lineCap: "square", 
                         lineJoin: "square",
                         // shadow: "rgba(0, 0, 0, 0.5)",
@@ -26,11 +26,9 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     let count = 0;
 
     // Path caching setup
-    let rectPathArray = [];
     let linePathArray = []; 
 
     // Predefine paths
-    let rectPath = new Path2D();
     let linePath = new Path2D();
 
     // Function to apply rectangle styles
@@ -52,11 +50,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
         // offscreenCtx.shadowOffsetY = lineStyle.shadowOffsetY;
     }
 
-    // Snap to integer pixel values
-    const snap = (val) => Math.round(val);
-
-    // Loop over only path cells (even rows and columns)
-    // Loop over all cells
+    // Loop over all cells, render only walls
     
     if (useCheckeredMode) {
         const checkeredSize = Math.max(2, Math.floor(cellSize * zoomLevel)); // Scale dynamically with zoom
@@ -83,63 +77,45 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
             const isEvenRow = y % 2 === 0;
             for (let x = 0; x < cols; x++) {
                 const isEvenCol = x % 2 === 0;
-
-                if (labyrinthData[y][x] === 0 && !isEvenRow && !isEvenCol) {
-                    // Path cell
-                    const rect_x = (x - 1) / 2;
-                    const rect_y = (y - 1) / 2;
-                    rectPath.rect(snap(rect_x * cellSize), snap(rect_y * cellSize), cellSize, cellSize);
-
-                } else if (labyrinthData[y][x] === 1) {
+                if (labyrinthData[y][x] === 1) {
                     // Wall cells
                     if (isEvenRow && !isEvenCol) {
                         // Horizontal walls in even rows
                         const rect_x = (x - 1) / 2;
                         const rect_y = y / 2;
-                        linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
-                        linePath.lineTo(snap((rect_x + 1) * cellSize), snap(rect_y * cellSize));
+                        linePath.moveTo(rect_x * cellSize, rect_y * cellSize);
+                        linePath.lineTo((rect_x + 1) * cellSize, rect_y * cellSize);
                     } else if (!isEvenRow && isEvenCol) {
                         // Vertical walls in odd rows
                         const rect_x = x / 2;
                         const rect_y = (y - 1) / 2;
-                        linePath.moveTo(snap(rect_x * cellSize), snap(rect_y * cellSize));
-                        linePath.lineTo(snap(rect_x * cellSize), snap((rect_y + 1) * cellSize));
+                        linePath.moveTo(rect_x * cellSize, rect_y * cellSize);
+                        linePath.lineTo(rect_x * cellSize, (rect_y + 1) * cellSize);
                     }
                 }
 
                 // Handle batching
                 if (++count >= batchSize) {
-                    // applyRectStyles();
-                    // offscreenCtx.fill(rectPath);
-                    // offscreenCtx.stroke(rectPath);
-
-                    // applyLineStyles();
-                    // offscreenCtx.stroke(linePath);
-                    rectPathArray.push(rectPath);
                     linePathArray.push(linePath);
-
-                    rectPath = new Path2D();
                     linePath = new Path2D();
                     count = 0;
                 }
             }
         }
+        linePathArray.push(linePath);
+        
+        // Render remaining batch
+        applyRectStyles();
+        offscreenCtx.fillRect(0, 0,
+            (cols - 1) / 2 * cellSize, 
+            (rows - 1) / 2 * cellSize
+        );
+        applyLineStyles();
+        for (const path of linePathArray) {
+            offscreenCtx.stroke(path);
+        }
+        // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
     }    
-    rectPathArray.push(rectPath);
-    linePathArray.push(linePath);
-
-    // Render remaining batch
-    applyRectStyles();
-    for (const path of rectPathArray) {
-        offscreenCtx.fill(path);
-        offscreenCtx.stroke(path);
-    }
-
-    applyLineStyles();
-    for (const path of linePathArray) {
-        offscreenCtx.stroke(path);
-    }
-    // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
 }
 
 // Export the function to make it accessible

--- a/assets/js/01_drawLabyrinth.js
+++ b/assets/js/01_drawLabyrinth.js
@@ -5,9 +5,11 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     // Disable anti-aliasing (optional)
     offscreenCtx.imageSmoothingEnabled = false;
     const canvasWidth = offscreenCtx.canvas.width;
+    const canvasHeight = offscreenCtx.canvas.height;
 
     // Dynamic checkered mode for small scales
-    const useCheckeredMode = cellSize <= 0.005 * canvasWidth;
+    // Use checkered mode if cell size is smaller than 0.5% of the smaller canvas dimension
+    const useCheckeredMode = cellSize <= 0.005 * Math.min(canvasHeight, canvasWidth);
     // Configuration constants
     const batchSize = 500;
     const rectStyle = { fill: "white", stroke: "white", lineWidth: 1 };
@@ -137,7 +139,7 @@ function drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthDat
     for (const path of linePathArray) {
         offscreenCtx.stroke(path);
     }
-    console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
+    // console.timeEnd('drawLabyrinthOffscreenExecutionTime'); // End the timer
 }
 
 // Export the function to make it accessible

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -42,7 +42,8 @@ function initializeCanvasManager(canvasId, labyrinthData) {
         mazeStyle: JSON.parse(window.localStorage.getItem('maze-style-store')),
         cellSize: null,
         mazeCellCounts: {x: null, y: null},
-        mazeStyleUpdated: false
+        mazeStyleUpdated: false,
+        canvasResized: false
     };
 
     // Canvas setup
@@ -134,7 +135,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
     // Cleanup function
     const cleanup = () => {
         console.log("Cleaning up canvas manager...");
-        handleEventListeners(canvas, State, mode = "remove");
+        handleEventListeners(canvas, offscreenCanvas, State, mode = "remove");
         if (animationFrameId) cancelAnimationFrame(animationFrameId);
         offscreenCtx.clearRect(0, 0, offscreenCanvas.width, offscreenCanvas.height);
         ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -154,7 +155,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
     
     // Track active manager
     activeCanvasManager = { cleanup };
-    handleEventListeners(canvas, State, mode = "attach");
+    handleEventListeners(canvas, offscreenCanvas, State, mode = "attach");
 
 };
 

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -99,6 +99,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
         // full virtual/world size = canvas.width * zoomFactor
         // offsets should be in virtual world size units - they include zoom
             // Avoid re-rendering if offsets and zoom are unchanged
+        console.time('drawVisibleCells');
         if (
             prevOffsetX === renderedImageCanvasOffsetX &&
             prevOffsetY === renderedImageCanvasOffsetY &&
@@ -222,7 +223,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
         ctx.fillText(scaleIndicatorText, 8, canvas.height - 15);
 
 
-        // console.timeEnd('Rendering visible cells:');
+        console.timeEnd('drawVisibleCells');
 
     };
 

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -188,9 +188,24 @@ function initializeCanvasManager(canvasId, labyrinthData) {
             compensatePanning(); // Only compensate when no panning or zooming is happening
 
 
-
-            // Stop animating when offsets are close enough to the target
-            if (
+            if (isMinimapAnimating) {
+                
+                // Handle minimap animation first
+                renderedImageCanvasOffsetX = lerp(renderedImageCanvasOffsetX, minimapTargetOffsetX, animationSpeed);
+                renderedImageCanvasOffsetY = lerp(renderedImageCanvasOffsetY, minimapTargetOffsetY, animationSpeed);
+                drawVisibleCells(); // Redraw during minimap animation
+    
+                // Stop minimap animation if close enough
+                if (
+                    Math.abs(renderedImageCanvasOffsetX - minimapTargetOffsetX) <= 0.5 &&
+                    Math.abs(renderedImageCanvasOffsetY - minimapTargetOffsetY) <= 0.5
+                ) {
+                    renderedImageCanvasOffsetX = minimapTargetOffsetX; // Snap to target
+                    renderedImageCanvasOffsetY = minimapTargetOffsetY;
+                    isMinimapAnimating = false; // End minimap animation
+                }
+            } else if (
+                // If minimap is not animating and compensation is needed
                 Math.abs(renderedImageCanvasOffsetX - compensatePanningOffsetX) > 0.5 ||
                 Math.abs(renderedImageCanvasOffsetY - compensatePanningOffsetY) > 0.5
             ) {
@@ -204,22 +219,6 @@ function initializeCanvasManager(canvasId, labyrinthData) {
                 ) {
                     renderedImageCanvasOffsetX = compensatePanningOffsetX; // Snap to target
                     renderedImageCanvasOffsetY = compensatePanningOffsetY;
-                }
-            } else if (isMinimapAnimating) {
-                
-                // Handle minimap animation if no compensate panning is required
-                renderedImageCanvasOffsetX = lerp(renderedImageCanvasOffsetX, minimapTargetOffsetX, animationSpeed);
-                renderedImageCanvasOffsetY = lerp(renderedImageCanvasOffsetY, minimapTargetOffsetY, animationSpeed);
-                drawVisibleCells(); // Redraw during minimap animation
-    
-                // Stop minimap animation if close enough
-                if (
-                    Math.abs(renderedImageCanvasOffsetX - minimapTargetOffsetX) <= 0.5 &&
-                    Math.abs(renderedImageCanvasOffsetY - minimapTargetOffsetY) <= 0.5
-                ) {
-                    renderedImageCanvasOffsetX = minimapTargetOffsetX; // Snap to target
-                    renderedImageCanvasOffsetY = minimapTargetOffsetY;
-                    isMinimapAnimating = false; // End minimap animation
                 }
             }
         }

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -38,19 +38,19 @@ function initializeCanvasManager(canvasId, labyrinthData) {
 
     // Utility function to get zoom increment based on current and maximum zoom levels
     function getZoomIncrement(currentZoom, maxZoom) {
-        const zoomDistance = maxZoom - currentZoom;
+        const zoomDistance = Math.round(maxZoom - currentZoom);
         // Determine the increment based on zoom distance
     let increment;
 
     if (zoomDistance < 10) {
         // Close to max zoom, use a small increment (fine-grained zooming)
         increment = 0.2; // Scale it for precision
-    } else if (zoomDistance < 50) {
+    } else if (zoomDistance < 30) {
         // Moderate zoom, use a mid-range increment
-        increment = Math.max(0.3, zoomDistance * 0.01);
+        increment = 0.5;
     } else {
         // Far from max zoom, use a larger increment
-        increment = Math.max(2, zoomDistance * 0.05); // Cap it at a reasonable max
+        increment = 1; // Cap it at a reasonable max
     };
 
     return increment;
@@ -126,7 +126,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
         offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
         offscreenCtx.clearRect(0,0,offscreenCanvas.width, offscreenCanvas.height);
         offscreenCtx.setTransform(1, 0, 0, 1, visibleCellOffsetX, visibleCellOffsetY);
-        window.drawLabyrinthOffscreen(cellSize, visibleCellData.length, visibleCellData[0].length, offscreenCtx, visibleCellData);
+        window.drawLabyrinthOffscreen(cellSize, visibleCellData.length, visibleCellData[0].length, offscreenCtx, visibleCellData, zoomFactor);
         ctx.drawImage(offscreenCanvas, 0, 0);
         console.timeEnd('Rendering visible cells:');
 
@@ -247,7 +247,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
 
     // Main script - draw offscreen maze, draw the same image on main canvas, listen for pan or zoom events, animate
     // Draw labyrinth offscreen, then redraw on the main canvas
-    window.drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData);
+    window.drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData, zoomFactor);
     ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear the canvas
     ctx.drawImage(offscreenCanvas, 0, 0);  // Draw offscreen content onto the main canvas
     // Start the loop

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -1,450 +1,160 @@
+console.log("Loading canvas manager");
+
+let activeCanvasManager = null; // Track the active instance for cleanup
+
 function initializeCanvasManager(canvasId, labyrinthData) {
-    // Config
-    const animationSpeed = 0.05; // Adjust speed (0.1 = smooth, 1 = instant)
-    const zoomDelay = 500; // Delay in milliseconds after the last zoom event
-    const minTileSizeInMazeCells = 10;
-    const maxZoomFactor = Math.max(((labyrinthData.length - 1) / 2)/minTileSizeInMazeCells , ((labyrinthData[0].length - 1) / 2)/minTileSizeInMazeCells);
-    const minZoomFactor = 1;
-    
-    // State variables
-    let isZooming = false;
-    let zoomFactor = 1;
-    let zoomTimeout;
-    let zoomIncrement;
-
-    let isPanning = false;
-    let startingPanningCoords = { x: 0, y: 0 } // these coordinates track cursor coordinates at the time of LMB click that initialized panning
-  
-
-    // Below coordinates describe distance of the origin of rendered image
-    // from the main canvas origin (top left corner);
-    // the offset is updated when zooming and panning
-    let renderedImageCanvasOffsetCoords = { x: 0, y: 0 };
-
-    // Below coordinates describe what the offset should be to not display whitespace in the main canvas
-    // How to move image behind the main canvas to fill the main canvas with image
-    let compensatePanningOffsetCoords = { x: 0, y: 0 };
-
-    // Below 3 variables are needed for maze redraw function when zooming/panning
-    let prevOffsetCoords = { x: null, y: null};
-    let prevZoomFactor = null;
-
-    // Minimap variables
-    let miniMapOrigin, miniMapDimensions;
-    let minimapTargetOffsetCoords = { x: null, y: null};
-    let isMinimapAnimating = false;
-
-    // Maze style
-    let mazeStyle = JSON.parse(window.localStorage.getItem('maze-style-store'));
-
-    // Utility function used for animation
-    function lerp(start, end, t) {
-        return start * (1 - t) + end * t; // Linear interpolation formula
+    // Cleanup any existing instance
+    if (activeCanvasManager) {
+        activeCanvasManager.cleanup();
+        activeCanvasManager = null;
     }
+    
+    // Config
+    const minTileSizeInMazeCells = 10;
 
-    // Utility function to get zoom increment based on current and maximum zoom levels
-    function getZoomIncrement(currentZoom, maxZoom) {
-        const zoomDistance = Math.round(maxZoom - currentZoom);
-        // Determine the increment based on zoom distance
-        let increment;
+    // State variables
+    const State = {
+        animationSpeed: 0.05,
+        zoomDelay: 500,
+        maxZoomFactor: Math.max(((labyrinthData.length - 1) / 2)/minTileSizeInMazeCells , ((labyrinthData[0].length - 1) / 2)/minTileSizeInMazeCells),
+        minZoomFactor: 1,
+        isZooming: false,
+        zoomFactor: 1,
+        zoomTimeout: null,
+        zoomIncrement: null,
+        isPanning: false,
+        startingPanningCoords: { x: 0, y: 0 }, // these coordinates track cursor coordinates at the time of LMB click that initialized panning
 
-        if (zoomDistance < 10) {
-            // Close to max zoom, use a small increment (fine-grained zooming)
-            increment = 0.25; // Scale it for precision
-        } else if (zoomDistance < 30) {
-            // Moderate zoom, use a mid-range increment
-            increment = 0.5;
-        } else {
-            // Far from max zoom, use a larger increment
-            increment = 1; // Cap it at a reasonable max
-        };
-
-        return increment;
+        // Below coordinates describe distance of the origin of rendered image
+        // from the main canvas origin (top left corner);
+        // the offset is updated when zooming and panning
+        renderedImageCanvasOffsetCoords: { x: 0, y: 0 },
+        // Below coordinates describe what the offset should be to not display whitespace in the main canvas
+        // How to move image behind the main canvas to fill the main canvas with image
+        compensatePanningOffsetCoords: { x: 0, y: 0 },
+        // Below 2 variables are needed for maze redraw function when zooming/panning
+        prevOffsetCoords: { x: null, y: null},
+        prevZoomFactor: null,
+        miniMapOrigin: null,
+        miniMapDimensions: null,
+        minimapTargetOffsetCoords: { x: null, y: null},
+        isMinimapAnimating: false,
+        mazeStyle: JSON.parse(window.localStorage.getItem('maze-style-store')),
+        cellSize: null,
+        mazeCellCounts: {x: null, y: null},
+        mazeStyleUpdated: false
     };
 
-    function keywiseOperation(arg1, arg2, operation) {
-        const result = {};
-        // Check if the second argument is an object or a number
-        if (typeof arg2 === 'object' && arg2 !== null && !Array.isArray(arg2)) {
-        // obj2OrNum is an object: Perform key-wise operations
-        for (const key of Object.keys(arg1)) {
-            if (arg2.hasOwnProperty(key)) {
-            result[key] = operation(arg1[key], arg2[key]);
-            } else {
-            throw new Error(`Key "${key}" is missing in the second object`);
-            }
-        }
-        } else if (typeof arg2 === 'number') {
-        // obj2OrNum is a number: Perform operations with a scalar
-        for (const key of Object.keys(arg1)) {
-            result[key] = operation(arg1[key], arg2);
-        }
-        } else {
-        throw new Error("Second argument must be either an object or a number");
-        }
-
-        return result;
-    }
-
     // Canvas setup
-    const canvas = document.getElementById(canvasId);
+    let canvas = document.getElementById(canvasId);
     if (!canvas) return;
 
     // Dynamically set canvas dimensions
     const rect = canvas.getBoundingClientRect();
     canvas.width = rect.width;
     canvas.height = rect.height;
-    const ctx = canvas.getContext("2d");
+    let ctx = canvas.getContext("2d");
 
     const mazeDataDimensions = {
         x: labyrinthData[0].length,
         y: labyrinthData.length
     };
 
-    const mazeCellCounts = keywiseOperation(mazeDataDimensions, 0, (val, _) => (val - 1) / 2);
+    State.mazeCellCounts = keywiseOperation(mazeDataDimensions, 0, (val, _) => (val - 1) / 2);
     // Calculate cell size and adjust canvas dimensions
     // Pick smaller cell size to fit a bigger portion of the image
-    let cellSize = Math.min(
-        (canvas.width * zoomFactor) / mazeCellCounts.x,
-        (canvas.height * zoomFactor) / mazeCellCounts.y
+    State.cellSize = Math.min(
+        (canvas.width * State.zoomFactor) / State.mazeCellCounts.x,
+        (canvas.height * State.zoomFactor) / State.mazeCellCounts.y
     ); // shared between main and offscreen
 
     // Set up offscreen canvas
-    const offscreenCanvas = document.createElement('canvas');
-    const offscreenCtx = offscreenCanvas.getContext('2d');
+    let offscreenCanvas = document.createElement('canvas');
+    let offscreenCtx = offscreenCanvas.getContext('2d');
     offscreenCanvas.width = canvas.width;
     offscreenCanvas.height = canvas.height;
 
-    function drawVisibleCells(forceDraw=false) {
-        // full virtual/world size = canvas.width * zoomFactor
-        // offsets should be in virtual world size units - they include zoom
-            // Avoid re-rendering if offsets and zoom are unchanged
-        console.time('drawVisibleCells');
-        if (
-            Object.values(
-                keywiseOperation(prevOffsetCoords, renderedImageCanvasOffsetCoords, (x,y) => (x === y)) // prevOffset same as renderedImageCanvasOffset
-            ).every(val => val === true) &&
-            prevZoomFactor === zoomFactor &&
-            forceDraw === false
-        ) {
-            return; // No change — skip rendering
-        }
-
-        // console.time('Rendering visible cells:');
-        // console.log('Rendering visible cells at zoom: ', zoomFactor);
-        // Update cached values to the current ones
-        prevOffsetCoords = {...renderedImageCanvasOffsetCoords};
-        prevZoomFactor = zoomFactor;
-
-        cellSize = Math.min(
-            (canvas.width * zoomFactor) / mazeCellCounts.x,
-            (canvas.height * zoomFactor) / mazeCellCounts.y
-        ); // shared between main and offscreen
-
-        // using cells indexes (0-based) below, not maze data grid coordinates
-        const firstVisibleCellCoords = keywiseOperation(renderedImageCanvasOffsetCoords, 0, (coord, _) => (Math.max(0, Math.floor(-coord / cellSize))));
-        const lastVisibleCellCoords = {
-            x: Math.min(Math.ceil(((canvas.width - renderedImageCanvasOffsetCoords.x) / cellSize) -1), mazeCellCounts.x),
-            y: Math.min(Math.ceil(((canvas.height - renderedImageCanvasOffsetCoords.y) / cellSize) -1), mazeCellCounts.y)
-        };
-
-        // slicing maze data grid/ json array
-        const sliceStartCoords = keywiseOperation(firstVisibleCellCoords, 0, (coord, _) => coord * 2);
-        const sliceEndCoords = keywiseOperation(lastVisibleCellCoords, 0, (coord, _) => coord * 2 + 3);
-
-        // console.log('Visible cells along X: ', firstVisibleCellX, ' to ', lastVisibleCellX);
-        // console.log('Visible cells along Y: ', firstVisibleCellY, ' to ', lastVisibleCellY);
-        
-        // console.time('json slicing');
-        const visibleCellData = labyrinthData.slice(sliceStartCoords.y, sliceEndCoords.y).map(row => row.slice(sliceStartCoords.x, sliceEndCoords.x));
-        // console.log('Data slice: ', 'y1 = ', sliceStartY, 'y2 = ', sliceEndY, 'x1 = ', sliceStartX, 'x2 = ', sliceEndX);
-        // console.timeEnd('json slicing');
-        const visibleCellOffsetCoords = keywiseOperation(renderedImageCanvasOffsetCoords, cellSize, (offset, cell_size) => (offset >= 0) ? offset : offset % cell_size);
-
-        ctx.clearRect(0, 0, canvas.width, canvas.height); // clear canvas
-
-        offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
-        offscreenCtx.clearRect(0,0,offscreenCanvas.width, offscreenCanvas.height);
-        offscreenCtx.setTransform(1, 0, 0, 1, visibleCellOffsetCoords.x, visibleCellOffsetCoords.y);
-        window.drawLabyrinthOffscreen(cellSize, visibleCellData.length, visibleCellData[0].length, offscreenCtx, visibleCellData, zoomFactor, mazeStyle);
-        ctx.drawImage(offscreenCanvas, 0, 0);
-        
-        // Mini-map dimensions ( max 10% of canvas along smaller dimension)
-        const miniMapSizeFactor = Math.max(
-            (mazeCellCounts.x * cellSize) / (canvas.width * 0.1),
-            (mazeCellCounts.y * cellSize) / (canvas.height * 0.1)
-        );
-        miniMapDimensions = keywiseOperation(mazeCellCounts, 0, (cells, _) => cells * cellSize / miniMapSizeFactor);
-
-        // Mini-map position (bottom-right corner)
-        miniMapOrigin = {
-            x: canvas.width - miniMapDimensions.x - 10,
-            y: canvas.height - miniMapDimensions.y - 30,
-        }
-
-        // Scale factors for mini-map
-        const miniMapScale = keywiseOperation(miniMapDimensions, mazeCellCounts, (dimension, cell_count) => dimension / cell_count);
-
-        // Draw mini-map background
-        ctx.fillStyle = 'rgba(200, 200, 200, 0.8)'; // Light gray background
-        ctx.fillRect(miniMapOrigin.x, miniMapOrigin.y, miniMapDimensions.x, miniMapDimensions.y);
-        ctx.strokeStyle = 'rgba(0, 0, 0, 0.8)'; // Border
-        ctx.strokeRect(miniMapOrigin.x, miniMapOrigin.y, miniMapDimensions.x, miniMapDimensions.y);
-
-        // Calculate viewport position inside mini-map
-        const viewportOrigin = {
-            x: miniMapOrigin.x + (-renderedImageCanvasOffsetCoords.x / cellSize) * miniMapScale.x,
-            y: miniMapOrigin.y + (-renderedImageCanvasOffsetCoords.y / cellSize) * miniMapScale.y
-        };
-        const viewportDimensions = {
-            x: (canvas.width / cellSize) * miniMapScale.x,
-            y: (canvas.height / cellSize) * miniMapScale.y,
-        };
-
-
-        // Draw viewport rectangle
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.5)'; // Semi-transparent white
-        ctx.fillRect(viewportOrigin.x, viewportOrigin.y, viewportDimensions.x, viewportDimensions.y);
-        ctx.strokeStyle = 'rgba(0, 0, 0, 0.7)'; // Border
-        ctx.strokeRect(viewportOrigin.x, viewportOrigin.y, viewportDimensions.x, viewportDimensions.y);
-
-        // Set styles for text rendering
-        ctx.font = '16px Arial';
-        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-        ctx.textAlign = 'right';
-        ctx.textBaseline = 'bottom';
-
-        // Draw the zoom level at bottom-right corner
-        const text = `Zoom: ${zoomFactor.toFixed(2)}x`;
-        ctx.fillText(text, canvas.width - 10, canvas.height - 10);
-
-        // Draw scale indicator
-        let scaleIndicatorSize = 0;
-        const indicatorSizeInCells = (canvas.width * 0.1) / cellSize;
-        const divisors = [10, 5, 1, 0.5];
-        
-        // Loop through divisors and find the first match
-        for (let divisor of divisors) {
-            const indicatorSizeRounded = Math.floor(indicatorSizeInCells / divisor);
-            if (indicatorSizeRounded > 0) {
-                scaleIndicatorSize = indicatorSizeRounded * divisor; // Set the size based on divisor
-                break; // Exit loop early once a match is found
-            }
-        }
-        const scaleIndicatorLength = scaleIndicatorSize * cellSize;
-        const scaleIndicatorText = `${scaleIndicatorSize} ${scaleIndicatorSize === 1 ? 'cell' : 'cells'}`;
-        ctx.beginPath();
-        ctx.moveTo(10, canvas.height - 10);
-        ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 10);
-        ctx.moveTo(10, canvas.height - 13);
-        ctx.lineTo(10, canvas.height - 7);
-        ctx.moveTo(10 + scaleIndicatorLength, canvas.height - 13);
-        ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 7);
-        ctx.strokeStyle = '#000000';
-        ctx.stroke();
-        ctx.textAlign = 'left';
-        ctx.fillText(scaleIndicatorText, 8, canvas.height - 15);
-
-
-        console.timeEnd('drawVisibleCells');
-
-    };
+    
 
     // Main animation loop
+    let animationFrameId = null;
     function renderLoop() {
-        if (!isPanning && !isZooming) {
-            compensatePanning(); // Only compensate when no panning or zooming is happening
-            // console.log("compens cond", Math.abs(renderedImageCanvasOffsetCoords.x), Math.abs(compensatePanningOffsetCoords.x));
 
-            if (isMinimapAnimating) {
-                
-                // Handle minimap animation first
-                renderedImageCanvasOffsetCoords = keywiseOperation(
-                    renderedImageCanvasOffsetCoords, 
-                    minimapTargetOffsetCoords,
-                    (origin, target) => lerp(origin, target, animationSpeed)
-                );
-                drawVisibleCells(); // Redraw during minimap animation
-    
-                // Stop minimap animation if close enough
-                if (
-                    Math.abs(renderedImageCanvasOffsetCoords.x - minimapTargetOffsetCoords.x) <= 0.5 &&
-                    Math.abs(renderedImageCanvasOffsetCoords.y - minimapTargetOffsetCoords.y) <= 0.5
-                ) {
-                    renderedImageCanvasOffsetCoords = {...minimapTargetOffsetCoords}; // Snap to target
-                    isMinimapAnimating = false; // End minimap animation
-                }
-            } else if (
-                // If minimap is not animating and compensation is needed
-                Math.abs(renderedImageCanvasOffsetCoords.x - compensatePanningOffsetCoords.x) > 0.5 ||
-                Math.abs(renderedImageCanvasOffsetCoords.y - compensatePanningOffsetCoords.y) > 0.5
+        compensatePanning(State, canvas); 
+
+        if (State.isMinimapAnimating) {
+            
+            // Handle minimap animation first
+            State.renderedImageCanvasOffsetCoords = keywiseOperation(
+                State.renderedImageCanvasOffsetCoords, 
+                State.minimapTargetOffsetCoords,
+                (origin, target) => lerp(origin, target, State.animationSpeed)
+            );
+            drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, labyrinthData); // Redraw during minimap animation
+
+            // Stop minimap animation if close enough
+            if (
+                Math.abs(State.renderedImageCanvasOffsetCoords.x - State.minimapTargetOffsetCoords.x) <= 0.5 &&
+                Math.abs(State.renderedImageCanvasOffsetCoords.y - State.minimapTargetOffsetCoords.y) <= 0.5
             ) {
-                renderedImageCanvasOffsetCoords = keywiseOperation(
-                    renderedImageCanvasOffsetCoords, 
-                    compensatePanningOffsetCoords,
-                    (origin, target) => lerp(origin, target, animationSpeed)
-                );
-                // Redraw with updated offsets
-                drawVisibleCells();
-                if (
-                    Math.abs(renderedImageCanvasOffsetCoords.x - compensatePanningOffsetCoords.x) <= 0.5 &&
-                    Math.abs(renderedImageCanvasOffsetCoords.y - compensatePanningOffsetCoords.y) <= 0.5
-                ) {
-                    renderedImageCanvasOffsetCoords = {...compensatePanningOffsetCoords}; // Snap to target
-                }
+                State.renderedImageCanvasOffsetCoords = {...State.minimapTargetOffsetCoords}; // Snap to target
+                State.isMinimapAnimating = false; // End minimap animation
             }
-        }
-        requestAnimationFrame(renderLoop); // Keep the loop running
-    };
+        } else if (
+            // If minimap is not animating and compensation is needed
+            Math.abs(State.renderedImageCanvasOffsetCoords.x - State.compensatePanningOffsetCoords.x) > 0.5 ||
+            Math.abs(State.renderedImageCanvasOffsetCoords.y - State.compensatePanningOffsetCoords.y) > 0.5
+        ) {
+            State.renderedImageCanvasOffsetCoords = keywiseOperation(
+                State.renderedImageCanvasOffsetCoords, 
+                State.compensatePanningOffsetCoords,
+                (origin, target) => lerp(origin, target, State.animationSpeed)
+            );
+            // Redraw with updated offsets
+            drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, labyrinthData);
+            if (
+                Math.abs(State.renderedImageCanvasOffsetCoords.x - State.compensatePanningOffsetCoords.x) <= 0.5 &&
+                Math.abs(State.renderedImageCanvasOffsetCoords.y - State.compensatePanningOffsetCoords.y) <= 0.5
+            ) {
+                State.renderedImageCanvasOffsetCoords = {...State.compensatePanningOffsetCoords}; // Snap to target
+            }
+        } else {drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, labyrinthData)};
 
-    //Function to automatically move (translate) canvas to avoid whitespace on screen
-    function compensatePanning() {
-        if (isPanning || isZooming) return;
-
-        compensatePanningOffsetCoords = {...renderedImageCanvasOffsetCoords};
-
-        const mazeWidth = mazeCellCounts.x * cellSize;
-        const mazeHeight = mazeCellCounts.y * cellSize;
-        // center image if image is smaller then canvas,
-        // align left or right border if margin is visible only from left or right
-        if (mazeWidth < canvas.width) {
-            compensatePanningOffsetCoords.x = (canvas.width - mazeWidth) / 2;
-        } else if (mazeWidth >= canvas.width && renderedImageCanvasOffsetCoords.x > 0) {
-            compensatePanningOffsetCoords.x = 0;
-        } else if (mazeWidth >= canvas.width && -renderedImageCanvasOffsetCoords.x > mazeWidth - canvas.width) {
-            compensatePanningOffsetCoords.x = -(mazeWidth - canvas.width);
-        }
-
-        if (mazeHeight < canvas.height) {
-            compensatePanningOffsetCoords.y = (canvas.height - mazeHeight) / 2;
-        } else if (mazeHeight >= canvas.height && renderedImageCanvasOffsetCoords.y > 0) {
-            compensatePanningOffsetCoords.y = 0;
-        } else if (mazeHeight >= canvas.height && -renderedImageCanvasOffsetCoords.y > mazeHeight - canvas.height) {
-            compensatePanningOffsetCoords.y = -(mazeHeight - canvas.height);
-        }
+        animationFrameId = requestAnimationFrame(renderLoop); // Keep the loop running
     };
     
-    // Zoom feature
-    canvas.addEventListener('wheel', (event) => {
-        isMinimapAnimating = false; // Cancel minimap animation
-        event.preventDefault();
-        if (!isZooming) isZooming = true;
-        const mousePosition = { // cursor position on canvas when event was triggered
-            x: event.offsetX,
-            y: event.offsetY
-        }
-
-        // where the cursor would have pointed in the image
-        // if no previous zooming or panning happened
-        // translation of cursor coordinates from Image to Canvas space;
-        // these operation cancel previous panning and zoom - coordinates without previous offset and zoom
-        // note: zoomFactor here is the original zoom or previous applied zoom
-        const worldPosition = keywiseOperation(mousePosition, renderedImageCanvasOffsetCoords, (mouse, offset) => (mouse - offset) / zoomFactor);
-
-        zoomIncrement = getZoomIncrement(zoomFactor, maxZoomFactor);
-
-        if (event.deltaY < 0) {
-            zoomFactor +=zoomIncrement;
-        } else {
-            zoomFactor -=zoomIncrement;
-        }
-        zoomFactor = Math.max(minZoomFactor, Math.min(zoomFactor, maxZoomFactor));
-
-        // how much to offset the image so that the cursor is still pointing at the same thing after zoom is applied
-        // world coordinates * zoomFactor = world coordinats with new zoom
-        // note: zoomFactor here is new zoom
-        renderedImageCanvasOffsetCoords = keywiseOperation(mousePosition, worldPosition, (m, w) => m - w * zoomFactor);
-        
-        drawVisibleCells();
-        // Debounce the end of zooming - do not compensate panning if zooming happens in quick succession
-        clearTimeout(zoomTimeout); // Clear any existing timeout
-        zoomTimeout = setTimeout(() => {
-            isZooming = false; // Mark zoom as complete after delay
-        }, zoomDelay); // Delay in milliseconds
-    });
-
-    // Panning Feature
-    canvas.addEventListener('mousedown', (event) => {
-        isMinimapAnimating = false; // Cancel minimap animation
-        isPanning = true; // Start panning
-        startingPanningCoords.x = event.clientX; // Track starting mouse position
-        startingPanningCoords.y = event.clientY;
-    });
-
-    canvas.addEventListener('mousemove', (event) => {
-        if (!isPanning) return; // Only pan if mouse is pressed
-
-        // Calculate the mouse movement (delta)
-        const deltaCoords = {
-            x: event.clientX - startingPanningCoords.x,
-            y: event.clientY - startingPanningCoords.y
-        };
-
-        // Update offsets based on mouse movement
-        renderedImageCanvasOffsetCoords = keywiseOperation(renderedImageCanvasOffsetCoords, deltaCoords, (coords, delta) => coords + delta);
-
-        // Update start position for next frame
-        startingPanningCoords.x = event.clientX;
-        startingPanningCoords.y = event.clientY;
-        
-        // Redraw with updated offsets
-        drawVisibleCells();
-    });
-
-    canvas.addEventListener('mouseup', () => {
-        isPanning = false; // Stop panning
-    });
-
-    canvas.addEventListener('mouseleave', () => {
-        isPanning = false; // Stop panning if mouse leaves canvas
-    });
-
-    // Click-to-move support for mini-map
-    canvas.addEventListener('click', (e) => {
-        const mouseX = e.offsetX;
-        const mouseY = e.offsetY;
-
-        // Check if the click is inside the mini-map bounds
-        if (
-            mouseX >= miniMapOrigin.x &&
-            mouseX <= miniMapOrigin.x + miniMapDimensions.x &&
-            mouseY >= miniMapOrigin.y &&
-            mouseY <= miniMapOrigin.y + miniMapDimensions.y
-        ) {
-            // Calculate the relative position inside the mini-map
-            const scale = keywiseOperation(miniMapDimensions, mazeCellCounts, (mapDim, cell_count) => mapDim / cell_count);
-
-            // Calculate the corresponding coordinates in the main canvas
-            const targetX = (mouseX - miniMapOrigin.x) / scale.x; // Corresponding X in the main maze
-            const targetY = (mouseY - miniMapOrigin.y) / scale.y; // Corresponding Y in the main maze
-
-            // Update the offsets to center the viewport on the clicked position
-            // Ensure the center of the clicked position on the mini-map corresponds to the center on the full canvas
-            minimapTargetOffsetCoords.x = -(targetX * cellSize) + canvas.width / 2;
-            minimapTargetOffsetCoords.y = -(targetY * cellSize) + canvas.height / 2;
-
-            // Clamp the offsets to avoid scrolling out of bounds
-            minimapTargetOffsetCoords.x = Math.min(0, Math.max(minimapTargetOffsetCoords.x, -mazeCellCounts.x * cellSize + canvas.width));
-            minimapTargetOffsetCoords.y = Math.min(0, Math.max(minimapTargetOffsetCoords.y, -mazeCellCounts.y * cellSize + canvas.height));
-
-            isMinimapAnimating = true; // Start minimap animation
-        }
-    });
-
-    // Styling
-    // Dynamic recoloring support
-    window.addEventListener('mazeStyleUpdated', (event) => {
-        mazeStyle = JSON.parse(window.localStorage.getItem('maze-style-store'));
-        drawVisibleCells(true);
-    });
-
-    compensatePanning();
-    renderedImageCanvasOffsetCoords = {...compensatePanningOffsetCoords};
+    compensatePanning(State, canvas);
+    State.renderedImageCanvasOffsetCoords = {...State.compensatePanningOffsetCoords};
 
     // Main script - draw offscreen maze, draw the same image on main canvas, listen for pan or zoom events, animate
-    drawVisibleCells();
+    drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, labyrinthData);
     // Start the loop
     renderLoop();
+
+    // Cleanup function
+    const cleanup = () => {
+        console.log("Cleaning up canvas manager...");
+        handleEventListeners(canvas, State, mode = "remove");
+        if (animationFrameId) cancelAnimationFrame(animationFrameId);
+        offscreenCtx.clearRect(0, 0, offscreenCanvas.width, offscreenCanvas.height);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        canvas.width = 0;
+        canvas.height = 0;
+
+        offscreenCanvas.width = 0;
+        offscreenCanvas.height = 0;
+
+        offscreenCanvas = null;
+        offscreenCtx = null;
+
+        canvas = null;
+        ctx = null;
+    };
+    
+    // Track active manager
+    activeCanvasManager = { cleanup };
+    handleEventListeners(canvas, State, mode = "attach");
 
 };
 

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -3,7 +3,7 @@ function initializeCanvasManager(canvasId, labyrinthData) {
     const animationSpeed = 0.05; // Adjust speed (0.1 = smooth, 1 = instant)
     const zoomDelay = 500; // Delay in milliseconds after the last zoom event
     const minTileSizeInMazeCells = 10;
-    const maxZoomFactor = Math.min(((labyrinthData.length - 1) / 2)/minTileSizeInMazeCells , ((labyrinthData[0].length - 1) / 2)/minTileSizeInMazeCells);
+    const maxZoomFactor = Math.max(((labyrinthData.length - 1) / 2)/minTileSizeInMazeCells , ((labyrinthData[0].length - 1) / 2)/minTileSizeInMazeCells);
     const minZoomFactor = 1;
     
     // State variables

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -14,17 +14,93 @@ function initializeCanvasManager(canvasId, labyrinthData) {
     const cols = labyrinthData[0].length;
 
     // Calculate integer cell size and adjust canvas dimensions
-    const cellSize = Math.ceil(canvas.width / ((cols - 1) / 2));
+    const cellSize = Math.floor(canvas.width / ((cols - 1) / 2));
     canvas.width = cellSize * ((cols - 1) / 2);
     canvas.height = cellSize * ((rows - 1) / 2);
 
+    // Set up offscreen canvas
     const offscreenCanvas = document.createElement('canvas');
     const offscreenCtx = offscreenCanvas.getContext('2d');
     offscreenCanvas.width = canvas.width;
     offscreenCanvas.height = canvas.height;
+    const offscreenCanvasCellSize = cellSize;
+
+    //Zoom feature
+    let zoomFactor = 1;
+    let maxZoomFactor = 2;
+    let minZoomFactor = 0.75;
+    let mouseZoomOffsetX = 0;
+    let mouseZoomOffsetY = 0;
+
+    // Panning Variables
+    let isPanning = false;
+    let startX = 0;
+    let startY = 0;
+    
+    canvas.addEventListener('wheel', (event) => {
+        event.preventDefault();
+
+        const mouseX = event.offsetX;
+        const mouseY = event.offsetY;
+
+        const worldX = (mouseX - mouseZoomOffsetX) / zoomFactor;
+        const worldY = (mouseY - mouseZoomOffsetY) / zoomFactor;
+
+        if (event.deltaY < 0) {
+            zoomFactor +=0.05;
+        } else {
+            zoomFactor -=0.05;
+        }
+        zoomFactor = Math.max(minZoomFactor, Math.min(zoomFactor, maxZoomFactor));
+
+        mouseZoomOffsetX = mouseX - worldX * zoomFactor;
+        mouseZoomOffsetY = mouseY - worldY * zoomFactor;
+        
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.setTransform(zoomFactor, 0, 0, zoomFactor, mouseZoomOffsetX, mouseZoomOffsetY); // Apply zoom transformation
+        ctx.drawImage(offscreenCanvas, 0, 0);  // Draw offscreen content onto the main canvas
+    });
+
+    // Panning Feature
+    canvas.addEventListener('mousedown', (event) => {
+        isPanning = true; // Start panning
+        startX = event.clientX; // Track starting mouse position
+        startY = event.clientY;
+    });
+
+    canvas.addEventListener('mousemove', (event) => {
+        if (!isPanning) return; // Only pan if mouse is pressed
+
+        // Calculate the mouse movement (delta)
+        const deltaX = (event.clientX - startX) / zoomFactor; // Scale movement by zoom
+        const deltaY = (event.clientY - startY) / zoomFactor;
+
+        // Update offsets based on mouse movement
+        mouseZoomOffsetX += deltaX;
+        mouseZoomOffsetY += deltaY;
+
+        // Update start position for next frame
+        startX = event.clientX;
+        startY = event.clientY;
+
+        // Redraw with updated offsets
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.setTransform(zoomFactor, 0, 0, zoomFactor, mouseZoomOffsetX, mouseZoomOffsetY);
+        ctx.drawImage(offscreenCanvas, 0, 0);
+    });
+
+    canvas.addEventListener('mouseup', () => {
+        isPanning = false; // Stop panning
+    });
+
+    canvas.addEventListener('mouseleave', () => {
+        isPanning = false; // Stop panning if mouse leaves canvas
+    });
 
     // Draw labyrinth offscreen, then redraw on the main canvas
-    window.drawLabyrinthOffscreen(cellSize, rows, cols, offscreenCtx, labyrinthData);
+    window.drawLabyrinthOffscreen(offscreenCanvasCellSize, rows, cols, offscreenCtx, labyrinthData);
     ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear the canvas
     ctx.drawImage(offscreenCanvas, 0, 0);  // Draw offscreen content onto the main canvas
 

--- a/assets/js/02_canvasManager.js
+++ b/assets/js/02_canvasManager.js
@@ -178,6 +178,34 @@ function initializeCanvasManager(canvasId, labyrinthData) {
         const text = `Zoom: ${zoomFactor.toFixed(2)}x`;
         ctx.fillText(text, canvas.width - 10, canvas.height - 10);
 
+        // Draw scale indicator
+        let scaleIndicatorSize = 0;
+        const indicatorSizeInCells = (canvas.width * 0.1) / cellSize;
+        const divisors = [10, 5, 1, 0.5];
+        
+        // Loop through divisors and find the first match
+        for (let divisor of divisors) {
+            const indicatorSizeRounded = Math.floor(indicatorSizeInCells / divisor);
+            if (indicatorSizeRounded > 0) {
+                scaleIndicatorSize = indicatorSizeRounded * divisor; // Set the size based on divisor
+                break; // Exit loop early once a match is found
+            }
+        }
+        const scaleIndicatorLength = scaleIndicatorSize * cellSize;
+        const scaleIndicatorText = `${scaleIndicatorSize} ${scaleIndicatorSize === 1 ? 'cell' : 'cells'}`;
+        ctx.beginPath();
+        ctx.moveTo(10, canvas.height - 10);
+        ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 10);
+        ctx.moveTo(10, canvas.height - 13);
+        ctx.lineTo(10, canvas.height - 7);
+        ctx.moveTo(10 + scaleIndicatorLength, canvas.height - 13);
+        ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 7);
+        ctx.strokeStyle = '#000000';
+        ctx.stroke();
+        ctx.textAlign = 'left';
+        ctx.fillText(scaleIndicatorText, 8, canvas.height - 15);
+
+
         console.timeEnd('Rendering visible cells:');
 
     };

--- a/assets/js/03_callbacks.js
+++ b/assets/js/03_callbacks.js
@@ -1,4 +1,4 @@
-// Define the clientside callback using Object.assign to avoid overwriting other namespaces
+// Callback initializing canvas manager
 window.dash_clientside = Object.assign({}, window.dash_clientside, {
     namespace: Object.assign({}, (window.dash_clientside || {}).namespace, {
         callbackManageLabyrinth: function(data) {
@@ -7,6 +7,19 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
             console.timeEnd('json_parsing');
             window.initializeCanvasManager("labyrinth-canvas", labyrinthData);  // Call drawing function
             return null;
+        }
+    })
+});
+
+// Callback dispatching event that triggers maze redraw when local storage is updated
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    namespace: Object.assign({}, (window.dash_clientside || {}).namespace, {
+        callbackUpdateLabyrinthStyle: function(wallColor) {
+                console.log('Style callback fired');
+                const event = new CustomEvent('mazeStyleUpdated');
+                const mazeStyle = {wallStroke: wallColor};
+                event.value = mazeStyle;
+                window.dispatchEvent(event);
         }
     })
 });

--- a/assets/js/03_callbacks.js
+++ b/assets/js/03_callbacks.js
@@ -14,10 +14,9 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
 // Callback dispatching event that triggers maze redraw when local storage is updated
 window.dash_clientside = Object.assign({}, window.dash_clientside, {
     namespace: Object.assign({}, (window.dash_clientside || {}).namespace, {
-        callbackUpdateLabyrinthStyle: function(wallColor) {
+        callbackUpdateLabyrinthStyle: function(mazeStyle) {
                 console.log('Style callback fired');
                 const event = new CustomEvent('mazeStyleUpdated');
-                const mazeStyle = {wallStroke: wallColor};
                 event.value = mazeStyle;
                 window.dispatchEvent(event);
         }

--- a/assets/js/canvas_functions.js
+++ b/assets/js/canvas_functions.js
@@ -1,0 +1,203 @@
+// Utility function to perform operation on objects, used here to operate on coordinates
+function keywiseOperation(arg1, arg2, operation) {
+    const result = {};
+    // Check if the second argument is an object or a number
+    if (typeof arg2 === 'object' && arg2 !== null && !Array.isArray(arg2)) {
+    // obj2OrNum is an object: Perform key-wise operations
+    for (const key of Object.keys(arg1)) {
+        if (arg2.hasOwnProperty(key)) {
+        result[key] = operation(arg1[key], arg2[key]);
+        } else {
+        throw new Error(`Key "${key}" is missing in the second object`);
+        }
+    }
+    } else if (typeof arg2 === 'number') {
+    // obj2OrNum is a number: Perform operations with a scalar
+    for (const key of Object.keys(arg1)) {
+        result[key] = operation(arg1[key], arg2);
+    }
+    } else {
+    throw new Error("Second argument must be either an object or a number");
+    }
+
+    return result;
+}
+
+// Utility function used for animation
+function lerp(start, end, t) {
+    return start * (1 - t) + end * t; // Linear interpolation formula
+}
+
+// Utility function to get zoom increment based on current and maximum zoom levels
+function getZoomIncrement(currentZoom, maxZoom) {
+    const zoomDistance = Math.round(maxZoom - currentZoom);
+    // Determine the increment based on zoom distance
+    let increment;
+
+    if (zoomDistance < 10) {
+        // Close to max zoom, use a small increment (fine-grained zooming)
+        increment = 0.25; // Scale it for precision
+    } else if (zoomDistance < 30) {
+        // Moderate zoom, use a mid-range increment
+        increment = 0.5;
+    } else {
+        // Far from max zoom, use a larger increment
+        increment = 1; // Cap it at a reasonable max
+    };
+
+    return increment;
+};
+
+//Function to automatically move (translate) canvas to avoid whitespace on screen
+function compensatePanning(State, canvas) {
+    State.compensatePanningOffsetCoords = {...State.renderedImageCanvasOffsetCoords}; // update compensation coordinates 
+
+    // center image if image is smaller then canvas,
+    // align left or right border if margin is visible only from left or right
+    if (!State.isPanning && !State.isZooming) { // compensate only if not zooming and not panning
+        const mazeWidth = State.mazeCellCounts.x * State.cellSize;
+        const mazeHeight = State.mazeCellCounts.y * State.cellSize;
+
+        if (mazeWidth < canvas.width) {
+            State.compensatePanningOffsetCoords.x = (canvas.width - mazeWidth) / 2;
+        } else if (mazeWidth >= canvas.width && State.renderedImageCanvasOffsetCoords.x > 0) {
+            State.compensatePanningOffsetCoords.x = 0;
+        } else if (mazeWidth >= canvas.width && -State.renderedImageCanvasOffsetCoords.x > mazeWidth - canvas.width) {
+            State.compensatePanningOffsetCoords.x = -(mazeWidth - canvas.width);
+        }
+
+        if (mazeHeight < canvas.height) {
+            State.compensatePanningOffsetCoords.y = (canvas.height - mazeHeight) / 2;
+        } else if (mazeHeight >= canvas.height && State.renderedImageCanvasOffsetCoords.y > 0) {
+            State.compensatePanningOffsetCoords.y = 0;
+        } else if (mazeHeight >= canvas.height && -State.renderedImageCanvasOffsetCoords.y > mazeHeight - canvas.height) {
+            State.compensatePanningOffsetCoords.y = -(mazeHeight - canvas.height);
+        }
+    }
+};
+
+function drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, labyrinthData) {
+    // full virtual/world size = canvas.width * zoomFactor
+    // offsets should be in virtual world size units - they include zoom
+    // Avoid re-rendering if offsets and zoom are unchanged
+    if (
+        Object.values(
+            keywiseOperation(State.prevOffsetCoords, State.renderedImageCanvasOffsetCoords, (x,y) => (x === y)) // prevOffset same as renderedImageCanvasOffset
+        ).every(val => val === true) &&
+        State.prevZoomFactor === State.zoomFactor &&
+        State.mazeStyleUpdated === false
+    ) {
+        return; // No change — skip rendering
+    }
+    console.time('drawVisibleCells');
+
+    // Update cached values to the current ones
+    State.mazeStyleUpdated = false;
+    State.prevOffsetCoords = {...State.renderedImageCanvasOffsetCoords};
+    State.prevZoomFactor = State.zoomFactor;
+
+    State.cellSize = Math.min(
+        (canvas.width * State.zoomFactor) / State.mazeCellCounts.x,
+        (canvas.height * State.zoomFactor) / State.mazeCellCounts.y
+    ); // shared between main and offscreen
+
+    // using cells indexes (0-based) below, not maze data grid coordinates
+    const firstVisibleCellCoords = keywiseOperation(State.renderedImageCanvasOffsetCoords, 0, (coord, _) => (Math.max(0, Math.floor(-coord / State.cellSize))));
+    const lastVisibleCellCoords = {
+        x: Math.min(Math.ceil(((canvas.width - State.renderedImageCanvasOffsetCoords.x) / State.cellSize) -1), State.mazeCellCounts.x),
+        y: Math.min(Math.ceil(((canvas.height - State.renderedImageCanvasOffsetCoords.y) / State.cellSize) -1), State.mazeCellCounts.y)
+    };
+
+    // slicing maze data grid/ json array
+    const sliceStartCoords = keywiseOperation(firstVisibleCellCoords, 0, (coord, _) => coord * 2);
+    const sliceEndCoords = keywiseOperation(lastVisibleCellCoords, 0, (coord, _) => coord * 2 + 3);
+
+    const visibleCellData = labyrinthData.slice(sliceStartCoords.y, sliceEndCoords.y).map(row => row.slice(sliceStartCoords.x, sliceEndCoords.x));
+    const visibleCellOffsetCoords = keywiseOperation(State.renderedImageCanvasOffsetCoords, State.cellSize, (offset, cell_size) => (offset >= 0) ? offset : offset % cell_size);
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height); // clear canvas
+
+    offscreenCtx.setTransform(1, 0, 0, 1, 0, 0);
+    offscreenCtx.clearRect(0,0,offscreenCanvas.width, offscreenCanvas.height);
+    offscreenCtx.setTransform(1, 0, 0, 1, visibleCellOffsetCoords.x, visibleCellOffsetCoords.y);
+    window.drawLabyrinthOffscreen(State.cellSize, visibleCellData.length, visibleCellData[0].length, offscreenCtx, visibleCellData, State.zoomFactor, State.mazeStyle);
+    ctx.drawImage(offscreenCanvas, 0, 0);
+    
+    // Mini-map dimensions ( max 10% of canvas along smaller dimension)
+    const miniMapSizeFactor = Math.max(
+        (State.mazeCellCounts.x * State.cellSize) / (canvas.width * 0.1),
+        (State.mazeCellCounts.y * State.cellSize) / (canvas.height * 0.1)
+    );
+    State.miniMapDimensions = keywiseOperation(State.mazeCellCounts, 0, (cells, _) => cells * State.cellSize / miniMapSizeFactor);
+
+    // Mini-map position (bottom-right corner)
+    State.miniMapOrigin = {
+        x: canvas.width - State.miniMapDimensions.x - 10,
+        y: canvas.height - State.miniMapDimensions.y - 30,
+    }
+
+    // Scale factors for mini-map
+    const miniMapScale = keywiseOperation(State.miniMapDimensions, State.mazeCellCounts, (dimension, cell_count) => dimension / cell_count);
+
+    // Draw mini-map background
+    ctx.fillStyle = 'rgba(200, 200, 200, 0.8)'; // Light gray background
+    ctx.fillRect(State.miniMapOrigin.x, State.miniMapOrigin.y, State.miniMapDimensions.x, State.miniMapDimensions.y);
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.8)'; // Border
+    ctx.strokeRect(State.miniMapOrigin.x, State.miniMapOrigin.y, State.miniMapDimensions.x, State.miniMapDimensions.y);
+
+    // Calculate viewport position inside mini-map
+    const viewportOrigin = {
+        x: State.miniMapOrigin.x + (-State.renderedImageCanvasOffsetCoords.x / State.cellSize) * miniMapScale.x,
+        y: State.miniMapOrigin.y + (-State.renderedImageCanvasOffsetCoords.y / State.cellSize) * miniMapScale.y
+    };
+    const viewportDimensions = {
+        x: (canvas.width / State.cellSize) * miniMapScale.x,
+        y: (canvas.height / State.cellSize) * miniMapScale.y,
+    };
+
+
+    // Draw viewport rectangle
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)'; // Semi-transparent white
+    ctx.fillRect(viewportOrigin.x, viewportOrigin.y, viewportDimensions.x, viewportDimensions.y);
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.7)'; // Border
+    ctx.strokeRect(viewportOrigin.x, viewportOrigin.y, viewportDimensions.x, viewportDimensions.y);
+
+    // Set styles for text rendering
+    ctx.font = '16px Arial';
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'bottom';
+
+    // Draw the zoom level at bottom-right corner
+    const text = `Zoom: ${State.zoomFactor.toFixed(2)}x`;
+    ctx.fillText(text, canvas.width - 10, canvas.height - 10);
+
+    // Draw scale indicator
+    let scaleIndicatorSize = 0;
+    const indicatorSizeInCells = (canvas.width * 0.1) / State.cellSize;
+    const divisors = [10, 5, 1, 0.5];
+    
+    // Loop through divisors and find the first match
+    for (let divisor of divisors) {
+        const indicatorSizeRounded = Math.floor(indicatorSizeInCells / divisor);
+        if (indicatorSizeRounded > 0) {
+            scaleIndicatorSize = indicatorSizeRounded * divisor; // Set the size based on divisor
+            break; // Exit loop early once a match is found
+        }
+    }
+    const scaleIndicatorLength = scaleIndicatorSize * State.cellSize;
+    const scaleIndicatorText = `${scaleIndicatorSize} ${scaleIndicatorSize === 1 ? 'cell' : 'cells'}`;
+    ctx.beginPath();
+    ctx.moveTo(10, canvas.height - 10);
+    ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 10);
+    ctx.moveTo(10, canvas.height - 13);
+    ctx.lineTo(10, canvas.height - 7);
+    ctx.moveTo(10 + scaleIndicatorLength, canvas.height - 13);
+    ctx.lineTo(10 + scaleIndicatorLength, canvas.height - 7);
+    ctx.strokeStyle = '#000000';
+    ctx.stroke();
+    ctx.textAlign = 'left';
+    ctx.fillText(scaleIndicatorText, 8, canvas.height - 15);
+
+    console.timeEnd('drawVisibleCells');
+};

--- a/assets/js/canvas_functions.js
+++ b/assets/js/canvas_functions.js
@@ -207,3 +207,22 @@ function drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, lab
 
     console.timeEnd('drawVisibleCells');
 };
+
+function hexToRgba(hex, alpha = 255) {
+    // Remove the '#' if present
+    hex = hex.replace(/^#/, '');
+
+    // Expand shorthand hex (#RGB to #RRGGBB)
+    if (hex.length === 3) {
+        hex = hex.split('').map(char => char + char).join('');
+    }
+
+    // Parse the hex color into red, green, and blue components
+    const bigint = parseInt(hex, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+
+    // Return the rgba color string
+    return [r, g, b, alpha];
+}

--- a/assets/js/canvas_functions.js
+++ b/assets/js/canvas_functions.js
@@ -85,21 +85,27 @@ function drawVisibleCells(State, canvas, ctx, offscreenCanvas, offscreenCtx, lab
             keywiseOperation(State.prevOffsetCoords, State.renderedImageCanvasOffsetCoords, (x,y) => (x === y)) // prevOffset same as renderedImageCanvasOffset
         ).every(val => val === true) &&
         State.prevZoomFactor === State.zoomFactor &&
-        State.mazeStyleUpdated === false
+        State.mazeStyleUpdated === false &&
+        State.canvasResized === false
     ) {
         return; // No change — skip rendering
     }
     console.time('drawVisibleCells');
 
+    if (State.prevZoomFactor !== State.zoomFactor) {
+        State.cellSize = Math.min(
+            (canvas.width * State.zoomFactor) / State.mazeCellCounts.x,
+            (canvas.height * State.zoomFactor) / State.mazeCellCounts.y
+        )
+    }; // shared between main and offscreen
+
     // Update cached values to the current ones
     State.mazeStyleUpdated = false;
+    State.canvasResized = false;
     State.prevOffsetCoords = {...State.renderedImageCanvasOffsetCoords};
     State.prevZoomFactor = State.zoomFactor;
 
-    State.cellSize = Math.min(
-        (canvas.width * State.zoomFactor) / State.mazeCellCounts.x,
-        (canvas.height * State.zoomFactor) / State.mazeCellCounts.y
-    ); // shared between main and offscreen
+
 
     // using cells indexes (0-based) below, not maze data grid coordinates
     const firstVisibleCellCoords = keywiseOperation(State.renderedImageCanvasOffsetCoords, 0, (coord, _) => (Math.max(0, Math.floor(-coord / State.cellSize))));

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -49,41 +49,78 @@ def create_labyrinth():
         children=[
             dmc.Group(
                 children=[
-                    dmc.ColorPicker(
-                        id="maze-wall-color-picker",
-                        format="hex",
-                        value="#63C5DA",
-                        fullWidth=True,
-                        persistence=True,
+                    dmc.Stack(
+                        children=[
+                            "Wall color",
+                            dmc.ColorPicker(
+                                id="maze-wall-color-picker",
+                                format="hex",
+                                value="#63C5DA",
+                                fullWidth=True,
+                                persistence=True,
+                            ),
+                        ],
+                        gap=5,
+                        flex=1,
                     ),
-                    dmc.ColorPicker(
-                        id="maze-path-color-picker",
-                        format="hex",
-                        value="#FFFFFF",
-                        fullWidth=True,
-                        persistence=True,
+                    dmc.Stack(
+                        children=[
+                            "Floor color",
+                            dmc.ColorPicker(
+                                id="maze-path-color-picker",
+                                format="hex",
+                                value="#FFFFFF",
+                                fullWidth=True,
+                                persistence=True,
+                            ),
+                        ],
+                        gap=5,
+                        flex=1,
                     ),
                 ],
                 wrap="nowrap",
             ),
-            dmc.Slider(
-                id="maze-width-slider",
-                value=10,
-                min=1,
-                max=500,
-                labelAlwaysOn=False,
-                persistence=True,
-            ),
-            dmc.Slider(
-                id="maze-height-slider",
-                value=10,
-                min=1,
-                max=500,
-                labelAlwaysOn=False,
-                persistence=True,
+            dmc.Stack(
+                children=[
+                    dmc.Checkbox(
+                        id="maze-square-mode-checkbox",
+                        checked=False,
+                        label="Render square maze",
+                        persistence=True,
+                    ),
+                    dmc.Group(
+                        children=[
+                            dmc.Text("Maze width", w=90),
+                            dmc.Slider(
+                                id="maze-width-slider",
+                                value=10,
+                                min=1,
+                                max=500,
+                                labelAlwaysOn=False,
+                                persistence=True,
+                                flex=4,
+                            ),
+                        ]
+                    ),
+                    dmc.Group(
+                        children=[
+                            dmc.Text("Maze height", w=90),
+                            dmc.Slider(
+                                id="maze-height-slider",
+                                value=10,
+                                min=1,
+                                max=500,
+                                labelAlwaysOn=False,
+                                persistence=True,
+                                flex=1,
+                            ),
+                        ]
+                    ),
+                ]
             ),
             dmc.Button(id="generate-maze-button", children=["Generate"]),
         ],
+        gap=60,
         flex=1,
     )
     return dmc.Group(children=[labyrinth, labyrinth_controls], h="100%")
@@ -96,8 +133,13 @@ def create_labyrinth():
     Input("generate-maze-button", "n_clicks"),  # Triggered on button click
     State("maze-width-slider", "value"),
     State("maze-height-slider", "value"),
+    State("maze-square-mode-checkbox", "checked"),
 )
-def generate_dfs_labyrinth_on_refresh(n_clicks, maze_width, maze_height):
+def generate_dfs_labyrinth_on_refresh(
+    n_clicks, maze_width, maze_height, square_mode_enabled
+):
+    if square_mode_enabled:
+        maze_height = maze_width
     labyrinth_data = generate_dfs_labyrinth(maze_width, maze_height)
 
     json_time = time.time()
@@ -132,3 +174,15 @@ clientside_callback(
     ClientsideFunction(namespace="namespace", function_name="callbackManageLabyrinth"),
     Input("labyrinth-data-store", "data"),
 )
+
+
+@callback(
+    Output("maze-height-slider", "disabled"),
+    Input("maze-square-mode-checkbox", "checked"),
+)
+def handle_square_mode(square_mode_enabled):
+    if square_mode_enabled:
+        height_slider_disabled = True
+    else:
+        height_slider_disabled = False
+    return height_slider_disabled

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -1,4 +1,5 @@
-from dash import html, callback, clientside_callback, ClientsideFunction, Input, Output
+from dash import html, callback, clientside_callback, ClientsideFunction, Input, Output, State, dcc
+import dash_mantine_components as dmc
 import json
 
 import random
@@ -10,39 +11,56 @@ def create_labyrinth():
     labyrinth = html.Div(
         id='labyrinth',
         children=[
-            html.Div(id="labyrinth-data", style={"display": "none"}, children=[]), #json.dumps(labyrinth_data)),
-            html.Div(id='dummy',children=[],style={"display": "none"}),
+            dcc.Store(id="labyrinth-data-store"),
             html.Canvas(
                 id='labyrinth-canvas',
                 children=[],
                 style={
-                    'width':'100%',
-                    'height':'100%'
+                    'height':'100%',
+                    'aspectRatio':1,
+                    'margin':'auto'
                 }
             )
         ],
         style={
-            'background': '#FFFFFF',
-            'max-height':'100%',
-            'max-width':'100%',
-            'aspect-ratio':'1',
-            'box-sizing':'border-box',
-            'border':'1px solid #000000',
-            'margin':'auto'
-            # 'flex':1,
-            # 'overflow':'hidden'
+            'display':'flex',
+            'align-content':'center',
+            'height':'100%',
+            'boxSizing':'border-box',
+            'margin':'auto',
+            'overflow':'hidden',
+            'flex':5
         }
     )
-    return labyrinth
+    labyrinth_controls = dmc.Stack(
+        id='labyrinth-controls',
+        children=[
+            dmc.Slider(
+                id='maze-size-slider',
+                value=10,
+                min=1,
+                max=500,
+                labelAlwaysOn=True,
+                persistence=True
+            ),
+            dmc.Button(
+                id='generate-maze-button',
+                children=['Generate']
+                
+            )
+        ],
+        flex=1
+    )
+    return dmc.Group(children=[labyrinth, labyrinth_controls], h='100%')
 
 # Callback to generate labyrinth data dynamically
 @callback(
-    Output("labyrinth-data", "children"),  # Send generated labyrinth data to this Div
+    Output("labyrinth-data-store", "data"),  # Send generated labyrinth data to Store
     Output("content-placeholder", "children"),
-    Input("labyrinth-canvas", "id")       # Triggered on page load
+    Input("generate-maze-button", "n_clicks"),       # Triggered on button click
+    State("maze-size-slider", "value")
 )
-def generate_dfs_labyrinth_on_refresh(_):
-    side_size = random.choice(range(50, 61))  # Define labyrinth size
+def generate_dfs_labyrinth_on_refresh(n_clicks, side_size):
     labyrinth_data = generate_dfs_labyrinth(side_size)
 
     json_time = time.time()
@@ -57,6 +75,6 @@ clientside_callback(
         namespace='namespace',
         function_name='callbackManageLabyrinth'
     ),
-    Output("dummy", "children"),
-    Input("labyrinth-data", "children")
+
+    Input("labyrinth-data-store", "data")
 )

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -18,8 +18,8 @@ def create_labyrinth():
                 children=[],
                 style={
                     'height':'100%',
-                    'aspectRatio':1,
-                    'margin':'auto'
+                    'width': '100%',
+                    'margin':'auto',
                 }
             )
         ],
@@ -30,7 +30,8 @@ def create_labyrinth():
             'boxSizing':'border-box',
             'margin':'auto',
             'overflow':'hidden',
-            'flex':5
+            'flex':5,
+            'background': '#FFFFFF'
         }
     )
     labyrinth_controls = dmc.Stack(

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -36,12 +36,24 @@ def create_labyrinth():
     labyrinth_controls = dmc.Stack(
         id='labyrinth-controls',
         children=[
-            dmc.ColorPicker(
-                id='maze-wall-color-picker',
-                format='hex',
-                value='#63C5DA',
-                fullWidth=True,
-                persistence=True
+            dmc.Group(
+                children=[
+                    dmc.ColorPicker(
+                        id='maze-wall-color-picker',
+                        format='hex',
+                        value='#63C5DA',
+                        fullWidth=True,
+                        persistence=True
+                    ),
+                    dmc.ColorPicker(
+                        id='maze-path-color-picker',
+                        format='hex',
+                        value='#FFFFFF',
+                        fullWidth=True,
+                        persistence=True
+                    ),
+                ],
+                wrap='nowrap',
             ),
             dmc.Slider(
                 id='maze-size-slider',
@@ -81,10 +93,11 @@ def generate_dfs_labyrinth_on_refresh(n_clicks, side_size):
 # Callback to update maze style information in dcc.Store
 @callback(
     Output("maze-style-store", "data"),
-    Input("maze-wall-color-picker", "value")
+    Input("maze-wall-color-picker", "value"),
+    Input("maze-path-color-picker", "value")
 )
-def update_maze_style_store(wall_color):
-    return {'wallStroke': wall_color}
+def update_maze_style_store(wall_color, path_color):
+    return {'wallStroke': wall_color, 'pathFill': path_color}
 
 # Callback to dispatch event that triggers maze redraw with new style
 clientside_callback( # TODO: decide if style needs to be applied with a button (button input to upload new styles to store) or continuously

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -12,6 +12,7 @@ def create_labyrinth():
         id='labyrinth',
         children=[
             dcc.Store(id="labyrinth-data-store"),
+            dcc.Store(id='maze-style-store', storage_type='local'),
             html.Canvas(
                 id='labyrinth-canvas',
                 children=[],
@@ -35,6 +36,13 @@ def create_labyrinth():
     labyrinth_controls = dmc.Stack(
         id='labyrinth-controls',
         children=[
+            dmc.ColorPicker(
+                id='maze-wall-color-picker',
+                format='hex',
+                value='#63C5DA',
+                fullWidth=True,
+                persistence=True
+            ),
             dmc.Slider(
                 id='maze-size-slider',
                 value=10,
@@ -69,6 +77,23 @@ def generate_dfs_labyrinth_on_refresh(n_clicks, side_size):
     print(f"\n json time: {json_time}")
     
     return labyrinth_data, side_size  # Send as JSON
+
+# Callback to update maze style information in dcc.Store
+@callback(
+    Output("maze-style-store", "data"),
+    Input("maze-wall-color-picker", "value")
+)
+def update_maze_style_store(wall_color):
+    return {'wallStroke': wall_color}
+
+# Callback to dispatch event that triggers maze redraw with new style
+clientside_callback( # TODO: decide if style needs to be applied with a button (button input to upload new styles to store) or continuously
+    ClientsideFunction(
+        namespace='namespace',
+        function_name='callbackUpdateLabyrinthStyle'
+    ),
+    Input("maze-style-store", "data")
+)
 
 clientside_callback(
     ClientsideFunction(

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -42,7 +42,7 @@ def create_labyrinth():
     Input("labyrinth-canvas", "id")       # Triggered on page load
 )
 def generate_dfs_labyrinth_on_refresh(_):
-    side_size = random.choice(range(50, 61))  # Define labyrinth size
+    side_size = random.choice(range(10, 501))  # Define labyrinth size
     labyrinth_data = generate_dfs_labyrinth(side_size)
 
     json_time = time.time()

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -141,8 +141,8 @@ def generate_dfs_labyrinth_on_refresh(
 ):
     if square_mode_enabled:
         maze_height = maze_width
-    # labyrinth_data = generate_dfs_labyrinth(maze_width, maze_height)
-    labyrinth_data = generate_random_grid(maze_width, maze_height)
+    labyrinth_data = generate_dfs_labyrinth(maze_width, maze_height)
+    # labyrinth_data = generate_random_grid(maze_width, maze_height)
 
     json_time = time.time()
     labyrinth_data = json.dumps(labyrinth_data)

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -42,7 +42,7 @@ def create_labyrinth():
     Input("labyrinth-canvas", "id")       # Triggered on page load
 )
 def generate_dfs_labyrinth_on_refresh(_):
-    side_size = random.choice(range(10, 501))  # Define labyrinth size
+    side_size = random.choice(range(15, 155))  # Define labyrinth size
     labyrinth_data = generate_dfs_labyrinth(side_size)
 
     json_time = time.time()

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -42,7 +42,7 @@ def create_labyrinth():
     Input("labyrinth-canvas", "id")       # Triggered on page load
 )
 def generate_dfs_labyrinth_on_refresh(_):
-    side_size = random.choice(range(15, 155))  # Define labyrinth size
+    side_size = random.choice(range(15, 800))  # Define labyrinth size
     labyrinth_data = generate_dfs_labyrinth(side_size)
 
     json_time = time.time()

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -51,12 +51,11 @@ def create_labyrinth():
                 children=[
                     dmc.Stack(
                         children=[
-                            "Wall color",
-                            dmc.ColorPicker(
+                            dmc.ColorInput(
                                 id="maze-wall-color-picker",
                                 format="hex",
                                 value="#63C5DA",
-                                fullWidth=True,
+                                label="Wall color",
                                 persistence=True,
                             ),
                         ],
@@ -65,12 +64,11 @@ def create_labyrinth():
                     ),
                     dmc.Stack(
                         children=[
-                            "Floor color",
-                            dmc.ColorPicker(
+                            dmc.ColorInput(
                                 id="maze-path-color-picker",
                                 format="hex",
                                 value="#FFFFFF",
-                                fullWidth=True,
+                                label="Floor color",
                                 persistence=True,
                             ),
                         ],
@@ -94,8 +92,9 @@ def create_labyrinth():
                             dmc.Slider(
                                 id="maze-width-slider",
                                 value=10,
-                                min=1,
+                                min=5,
                                 max=500,
+                                step=5,
                                 labelAlwaysOn=False,
                                 persistence=True,
                                 flex=4,
@@ -108,8 +107,9 @@ def create_labyrinth():
                             dmc.Slider(
                                 id="maze-height-slider",
                                 value=10,
-                                min=1,
+                                min=5,
                                 max=500,
+                                step=5,
                                 labelAlwaysOn=False,
                                 persistence=True,
                                 flex=1,

--- a/create_labyrinth.py
+++ b/create_labyrinth.py
@@ -15,6 +15,7 @@ import random
 import time
 
 from maze_generators.depth_first_search_generator import generate_dfs_labyrinth
+from maze_generators.random_grid_generator import generate_random_grid
 
 
 def create_labyrinth():
@@ -140,7 +141,8 @@ def generate_dfs_labyrinth_on_refresh(
 ):
     if square_mode_enabled:
         maze_height = maze_width
-    labyrinth_data = generate_dfs_labyrinth(maze_width, maze_height)
+    # labyrinth_data = generate_dfs_labyrinth(maze_width, maze_height)
+    labyrinth_data = generate_random_grid(maze_width, maze_height)
 
     json_time = time.time()
     labyrinth_data = json.dumps(labyrinth_data)

--- a/maze_generators/depth_first_search_generator.py
+++ b/maze_generators/depth_first_search_generator.py
@@ -1,7 +1,7 @@
 import time
 import random
 import numpy as np
-def generate_dfs_labyrinth(side_size):
+def generate_dfs_labyrinth(width, height = 20):
     """Generates a square maze using randomized depth-first search algorithm in iterative implementation"""
     # random.seed(43)
 
@@ -61,21 +61,21 @@ def generate_dfs_labyrinth(side_size):
         wall_removal_time += time.time() - start_time  # Accumulate wall removal time
 
     # Initialize timing variables
-    print(f"\nCreating a {side_size} by {side_size} maze")
+    print(f"\nCreating a {width} by {height} maze")
     neighbor_search_time = 0
     wall_removal_time = 0
     total_time = time.time()
 
     # set array size for the algorithm to work and fill it with ones (unvisited paths, walls not broken). 
     # (2*x + 1) formula provides size of an array that includes all internal and external walls
-    labyrinth_array_size = 2*side_size + 1
-    labyrinth_array = np.ones((labyrinth_array_size, labyrinth_array_size))
+    labyrinth_array_width, labyrinth_array_height = 2 * width + 1, 2 * height + 1
+    labyrinth_array = np.ones((labyrinth_array_height, labyrinth_array_width))
 
     # initialize stack
     stack = []
 
     # pick a random starting cell, mark it as visited (set value to 0), and push it to the stack
-    y, x = random.choice(range(1, labyrinth_array_size - 1, 2)), random.choice(range(1, labyrinth_array_size - 1, 2))
+    y, x = random.choice(range(1, labyrinth_array_height - 1, 2)), random.choice(range(1, labyrinth_array_width - 1, 2))
     labyrinth_array[y, x] = 0
     stack.append([y, x])
 

--- a/maze_generators/depth_first_search_generator.py
+++ b/maze_generators/depth_first_search_generator.py
@@ -1,7 +1,7 @@
 import time
 import random
 import numpy as np
-def generate_dfs_labyrinth(width, height = 20):
+def generate_dfs_labyrinth(width, height = None):
     """Generates a square maze using randomized depth-first search algorithm in iterative implementation"""
     # random.seed(43)
 
@@ -61,6 +61,8 @@ def generate_dfs_labyrinth(width, height = 20):
         wall_removal_time += time.time() - start_time  # Accumulate wall removal time
 
     # Initialize timing variables
+    if height==None:
+        height = width
     print(f"\nCreating a {width} by {height} maze")
     neighbor_search_time = 0
     wall_removal_time = 0

--- a/maze_generators/depth_first_search_generator.py
+++ b/maze_generators/depth_first_search_generator.py
@@ -110,7 +110,6 @@ def generate_dfs_labyrinth(width, height=None):
 
     labyrinth_array[-1][random.choice(range(1, labyrinth_array_width - 1, 2))] = 0
     labyrinth_array[0][random.choice(range(1, labyrinth_array_width - 1, 2))] = 0
-    print(labyrinth_array[0])
     total_time = time.time() - total_time
 
     print(f"Total Time: {total_time:.4f} seconds")

--- a/maze_generators/depth_first_search_generator.py
+++ b/maze_generators/depth_first_search_generator.py
@@ -1,7 +1,9 @@
 import time
 import random
 import numpy as np
-def generate_dfs_labyrinth(width, height = None):
+
+
+def generate_dfs_labyrinth(width, height=None):
     """Generates a square maze using randomized depth-first search algorithm in iterative implementation"""
     # random.seed(43)
 
@@ -16,12 +18,12 @@ def generate_dfs_labyrinth(width, height = None):
         rows, cols = labyrinth_array.shape
 
         # Check two positions away in the row (y-axis)
-        row_mask_up = (y - 2 >= 0)  # Valid index for y-2
-        row_mask_down = (y + 2 < rows)  # Valid index for y+2
+        row_mask_up = y - 2 >= 0  # Valid index for y-2
+        row_mask_down = y + 2 < rows  # Valid index for y+2
 
         # Check two positions away in the column (x-axis)
-        col_mask_left = (x - 2 >= 0)  # Valid index for x-2
-        col_mask_right = (x + 2 < cols)  # Valid index for x+2
+        col_mask_left = x - 2 >= 0  # Valid index for x-2
+        col_mask_right = x + 2 < cols  # Valid index for x+2
 
         # Using .where() to find valid positions along y-axis and x-axis
         if row_mask_up:
@@ -38,10 +40,14 @@ def generate_dfs_labyrinth(width, height = None):
             if labyrinth_array[y, x + 2] == 1:
                 unvisited_neighbors.append([y, x + 2])
 
-        neighbor_search_time += time.time() - start_time  # Accumulate neighbor search time
+        neighbor_search_time += (
+            time.time() - start_time
+        )  # Accumulate neighbor search time
         return unvisited_neighbors
-    
-    def remove_wall_between_neighbors(current_cell_coordinates: list, next_cell_coordinates: list):
+
+    def remove_wall_between_neighbors(
+        current_cell_coordinates: list, next_cell_coordinates: list
+    ):
         """Checks if cells at provided coordinates are neighbors, removes wall between them in maze array if true"""
         nonlocal wall_removal_time
         start_time = time.time()  # Start timing wall removal
@@ -54,21 +60,21 @@ def generate_dfs_labyrinth(width, height = None):
             # Calculate the wall coordinates as the midpoint between the two cells
             wall_y = (cy + ny) // 2
             wall_x = (cx + nx) // 2
-        
+
             # Remove the wall
             labyrinth_array[wall_y, wall_x] = 0
-        
+
         wall_removal_time += time.time() - start_time  # Accumulate wall removal time
 
     # Initialize timing variables
-    if height==None:
+    if height == None:
         height = width
     print(f"\nCreating a {width} by {height} maze")
     neighbor_search_time = 0
     wall_removal_time = 0
     total_time = time.time()
 
-    # set array size for the algorithm to work and fill it with ones (unvisited paths, walls not broken). 
+    # set array size for the algorithm to work and fill it with ones (unvisited paths, walls not broken).
     # (2*x + 1) formula provides size of an array that includes all internal and external walls
     labyrinth_array_width, labyrinth_array_height = 2 * width + 1, 2 * height + 1
     labyrinth_array = np.ones((labyrinth_array_height, labyrinth_array_width))
@@ -77,17 +83,23 @@ def generate_dfs_labyrinth(width, height = None):
     stack = []
 
     # pick a random starting cell, mark it as visited (set value to 0), and push it to the stack
-    y, x = random.choice(range(1, labyrinth_array_height - 1, 2)), random.choice(range(1, labyrinth_array_width - 1, 2))
+    y, x = random.choice(range(1, labyrinth_array_height - 1, 2)), random.choice(
+        range(1, labyrinth_array_width - 1, 2)
+    )
     labyrinth_array[y, x] = 0
     stack.append([y, x])
 
-    while stack: # ...is not empty
-        #current_cell = stack[-1]
-        current_cell = stack.pop() # pop the last element from stack, make it a current cell
+    while stack:  # ...is not empty
+        # current_cell = stack[-1]
+        current_cell = (
+            stack.pop()
+        )  # pop the last element from stack, make it a current cell
         current_cell_unvisited_neighbors = get_unvisited_cell_neighbors(current_cell)
-        if current_cell_unvisited_neighbors: # ...list is not empty
-            stack.append(current_cell) # assign current cell back to stack
-            next_cell = random.choice(current_cell_unvisited_neighbors) # choose next cell randomly
+        if current_cell_unvisited_neighbors:  # ...list is not empty
+            stack.append(current_cell)  # assign current cell back to stack
+            next_cell = random.choice(
+                current_cell_unvisited_neighbors
+            )  # choose next cell randomly
 
             # remove the wall between current and next cell, mark next cell as visited and add it to the stack
             remove_wall_between_neighbors(current_cell, next_cell)
@@ -95,8 +107,10 @@ def generate_dfs_labyrinth(width, height = None):
             stack.append(next_cell)
         # else:
         #     stack.pop()
-    
 
+    labyrinth_array[-1][random.choice(range(1, labyrinth_array_width - 1, 2))] = 0
+    labyrinth_array[0][random.choice(range(1, labyrinth_array_width - 1, 2))] = 0
+    print(labyrinth_array[0])
     total_time = time.time() - total_time
 
     print(f"Total Time: {total_time:.4f} seconds")

--- a/maze_generators/random_grid_generator.py
+++ b/maze_generators/random_grid_generator.py
@@ -1,5 +1,7 @@
 import random
-def generate_random_grid(side_size):
+
+
+def generate_random_grid(width, height):
     """
     Generates a 2D array filled with 0 and 1 values.
 
@@ -7,5 +9,8 @@ def generate_random_grid(side_size):
     :param cols: Number of columns in the array.
     :return: A 2D list (rows x cols) filled with 0 and 1 values.
     """
-    side_size = 2*side_size + 1
-    return [[random.choice([0, 1]) for _ in range(side_size)] for _ in range(side_size)]
+    labyrinth_array_width, labyrinth_array_height = 2 * width + 1, 2 * height + 1
+    return [
+        [random.choice([0, 1]) for _ in range(labyrinth_array_width)]
+        for _ in range(labyrinth_array_height)
+    ]


### PR DESCRIPTION
First batch of basic functionalities:

- Canvas controlled by canvas manager, implements relatively fast and accurate rendering (floating point coordinates, smooth camera, ~60FPS for 500x500 grid with cell size <4px), supports pan, zoom, autopanning to maze borders/center, minimap and zoom scale information, minimap click-to-move, live maze style updates, canvas resize on window resize
- Rendering adjusts for different maze and canvas aspect ratios
- Simple UI to control maze colors and dimensions of the generated maze, square maze mode allowing the user to only set 1 of 2 dimensions
- Temporarily disabled support for multi-color floor rendering (needed for future features)